### PR TITLE
Always compile TachBook in light library

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,8 +30,8 @@ cd ~/m2_kaspar
 # Build all libraries + kaspr executable (optimized)
 KSPRPROJ=~/m2_kaspar make
 
-# Build with MBO L3 order book (for live trading)
-KSPRPROJ=~/m2_kaspar USE_TACHBOOK=1 make
+# Rebuild kaspr executable with MBO L3 order book (for live trading)
+cd kaspr/src && KSPRPROJ=~/m2_kaspar USE_TACHBOOK=1 make
 
 # Build debug
 KSPRPROJ=~/m2_kaspar make debug

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ CME MDP3 Multicast (or PCAP file)
 # Build (optimized)
 KSPRPROJ=$(pwd) make -j6
 
-# Build with MBO L3 order book (for live trading)
-KSPRPROJ=$(pwd) USE_TACHBOOK=1 make -j6
+# Rebuild kaspr executable with MBO L3 order book (for live trading)
+cd kaspr/src && KSPRPROJ=~/m2_kaspar USE_TACHBOOK=1 make
 
 # Run with PCAP replay
 cd kaspr && ./kaspr config/kaspr.ini

--- a/light/src/Makefile
+++ b/light/src/Makefile
@@ -5,13 +5,7 @@
 
 include $(KSPRPROJ)/mk_kaspr/glob_begin.mk
 
-LIBSRC = light22.cpp QCoord.cpp PCoord.cpp
-
-# Optional: include TachBook MBO L3 order book (make USE_TACHBOOK=1)
-ifdef USE_TACHBOOK
-LIBSRC += TachBook.cpp
-DEFINES_COMMON += -DUSE_TACHBOOK
-endif
+LIBSRC = light22.cpp QCoord.cpp PCoord.cpp TachBook.cpp
 
 # Enable AVX2 for TachBook fast_compare function (x86 only)
 ifneq ($(UNAME_S),Darwin)


### PR DESCRIPTION
## Summary
- TachBook.cpp always compiled into liblight.a (no more conditional)
- USE_TACHBOOK=1 only needed for kaspr executable, not libraries
- Updated build docs in README.md and CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)