### PR TITLE
Add rust2 docs (README, DEVELOPER_GUIDE, MATCHING_ENGINE)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Named after [Kasprowy Wierch](https://en.wikipedia.org/wiki/Kasprowy_Wierch) —
 - **iLink 3 reference implementation** — Full CME iLink v3 session handler with SBE encoding, HMAC authentication, sequence management, and primary/secondary failover.
 - **PCAP reader** — Replay recorded CME multicast captures for deterministic backtesting. Bit-exact reproduction of market conditions.
 - **External strategy support** — Write strategies in C++ (in-process, lowest latency), or Python/Java via ZMQ remote actor messaging.
+- **Rust port of the actor framework** — [`actors/rust2`](actors/rust2) (crate `actors2`): a from-scratch Rust port of the actor core — on-stack `fast_send`, integer-ID O(1) dispatch, the `BQueue` mailbox, and the per-type object pool — shipping a **price-time-FIFO order-book matching engine** as an example. In-process (no remoting/registry/groups yet).
 
 ## Architecture
 
@@ -92,6 +93,7 @@ cd kaspr && ./kaspr config/kaspr.ini --reset-positions
 ```
 kaspar/
 ├── actors/          C++20 actor framework (messaging, lifecycle, ZMQ remoting)
+│   └── rust2/       Rust port of the actor framework (actors2) + matching_engine example
 ├── kaspr/           Main application (startup, wiring, config)
 ├── mdp3/            MDP3 market data decoder and recovery
 ├── mcast_recv/      Multicast UDP receiver and PCAP reader
@@ -140,7 +142,9 @@ Real market participant places order at 6050.00
 
 The lights coordinate via **lock-free shared memory** — `QCoord` tracks aggregate working orders, `PCoord` tracks net position. No messages, no locks, no contention.
 
-See [SHADOW_ALGORITHM.md](light/SHADOW_ALGORITHM.md) for the full specification.
+See [SHADOW_ALGORITHM.md](light/SHADOW_ALGORITHM.md) for the full specification, and the write-up
+**"Shadow POV Execution: Trade Where the Market Is Going to Trade"** on the author's
+[Substack](https://vincentmayeski.substack.com).
 
 ## Actor Framework
 
@@ -152,6 +156,14 @@ The actor framework provides the concurrency model for the entire system:
 - **Zero-copy fast path** — `fast_send()` executes handler in caller's thread for synchronous queries
 - **CPU affinity** — Pin actors to cores for deterministic latency
 - **Distributed deployment via ZMQ** — Actors communicate transparently across processes and machines. Run one actor group in NY4 and another in DC3 — actors use the same `send()` API whether the target is local or remote. `ZmqSender`/`ZmqReceiver` handle serialization and transport. Actors don't know or care if they're talking to a local thread or a remote process.
+- **Rust port** — [`actors/rust2`](actors/rust2) (`actors2`) is a from-scratch Rust port of the actor core (on-stack `fast_send`, integer-ID O(1) dispatch, `BQueue`, object pool). It is in-process only (no ZMQ/registry/groups yet) and ships a **matching engine** as an example — see its [README](actors/rust2/README.md) and [DEVELOPER_GUIDE](actors/rust2/DEVELOPER_GUIDE.md).
+
+The design behind the framework is written up here:
+[**The Actor Model for Low-Latency Software**](https://vincentmayeski.substack.com/p/the-actor-model-for-low-latency-software),
+[**A High-Performance Mailbox**](https://vincentmayeski.substack.com/p/high-performance-mailbox-in-the-kaspar)
+(the `BQueue`), and
+[**A Custom Memory Allocator (10× improvement)**](https://vincentmayeski.substack.com/p/a-custom-memory-allocator-for-the)
+(the object pool).
 
 ```cpp
 class MyStrategy : public Actor {
@@ -219,6 +231,9 @@ kaspr {
 | [ACTORS_INVENTORY.md](ACTORS_INVENTORY.md) | Every actor in the system |
 | [FILE_STRUCTURE.md](FILE_STRUCTURE.md) | Complete file and directory inventory |
 | [CLAUDE_AGENT_GUIDE.md](actors/cpp/CLAUDE_AGENT_GUIDE.md) | Actor framework technical reference |
+| [actors/rust2/README.md](actors/rust2/README.md) | Rust actor-framework port — overview & quickstart |
+| [actors/rust2/DEVELOPER_GUIDE.md](actors/rust2/DEVELOPER_GUIDE.md) | Writing actors in the Rust port |
+| [actors/rust2/MATCHING_ENGINE.md](actors/rust2/MATCHING_ENGINE.md) | The matching-engine example |
 
 ## Performance Characteristics
 
@@ -227,6 +242,15 @@ kaspr {
 - **Book update to strategy**: Single `EndOfBurst` message per MDP3 incremental cycle
 - **Memory**: Pool allocators for high-frequency message types, zero GC pauses
 - **Threading**: One thread per actor, CPU affinity pinning, no contention between instruments
+
+## Writing
+
+Deep-dives on the design behind Kaspar (author's Substack — [vincentmayeski.substack.com](https://vincentmayeski.substack.com)):
+
+- [**The Actor Model for Low-Latency Software**](https://vincentmayeski.substack.com/p/the-actor-model-for-low-latency-software) — a concurrency model invented for single-CPU machines turned out to be the right one for multicore.
+- [**A High-Performance Mailbox in the Kaspar C++ Actor System**](https://vincentmayeski.substack.com/p/high-performance-mailbox-in-the-kaspar) — ring buffers are great until they overflow (the `BQueue` design).
+- [**A Custom Memory Allocator for the Kaspar Actor System Gives 10× Improvement**](https://vincentmayeski.substack.com/p/a-custom-memory-allocator-for-the) — when you know the size at compile time, almost everything an allocator does becomes unnecessary (the object pool).
+- **Shadow POV Execution: Trade Where the Market Is Going to Trade** — a percentage-of-volume algorithm that follows passive flow (on the [Substack](https://vincentmayeski.substack.com)).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -143,8 +143,7 @@ Real market participant places order at 6050.00
 The lights coordinate via **lock-free shared memory** — `QCoord` tracks aggregate working orders, `PCoord` tracks net position. No messages, no locks, no contention.
 
 See [SHADOW_ALGORITHM.md](light/SHADOW_ALGORITHM.md) for the full specification, and the write-up
-**"Shadow POV Execution: Trade Where the Market Is Going to Trade"** on the author's
-[Substack](https://vincentmayeski.substack.com).
+[**"Shadow POV Execution: Trade Where the Market Is Going to Trade"**](https://vincentmayeski.substack.com/p/shadow-pov-execution-trade-where).
 
 ## Actor Framework
 
@@ -250,7 +249,7 @@ Deep-dives on the design behind Kaspar (author's Substack — [vincentmayeski.su
 - [**The Actor Model for Low-Latency Software**](https://vincentmayeski.substack.com/p/the-actor-model-for-low-latency-software) — a concurrency model invented for single-CPU machines turned out to be the right one for multicore.
 - [**A High-Performance Mailbox in the Kaspar C++ Actor System**](https://vincentmayeski.substack.com/p/high-performance-mailbox-in-the-kaspar) — ring buffers are great until they overflow (the `BQueue` design).
 - [**A Custom Memory Allocator for the Kaspar Actor System Gives 10× Improvement**](https://vincentmayeski.substack.com/p/a-custom-memory-allocator-for-the) — when you know the size at compile time, almost everything an allocator does becomes unnecessary (the object pool).
-- **Shadow POV Execution: Trade Where the Market Is Going to Trade** — a percentage-of-volume algorithm that follows passive flow (on the [Substack](https://vincentmayeski.substack.com)).
+- [**Shadow POV Execution: Trade Where the Market Is Going to Trade**](https://vincentmayeski.substack.com/p/shadow-pov-execution-trade-where) — a percentage-of-volume algorithm that follows passive flow.
 
 ## License
 

--- a/actors/rust2/DEVELOPER_GUIDE.md
+++ b/actors/rust2/DEVELOPER_GUIDE.md
@@ -1,0 +1,129 @@
+# actors2 — Developer Guide
+
+How to build actors with `actors2`. This documents the **actual `rust2` API** (which differs
+from the older channel-based Rust actor crate). See [`README.md`](README.md) for the big picture.
+
+## 1. Define messages (with integer IDs)
+
+Every message carries a **compile-time integer id** used for O(1) dispatch. IDs must be
+`< 1024`; ids `< 16` are reserved by the framework (`Start = 4`, `Shutdown = 5`).
+
+```rust
+use actors2::define_message;
+
+struct Ping { count: i32 }
+define_message!(Ping, 10);
+
+struct Pong { count: i32 }
+define_message!(Pong, 11);
+```
+
+For hot-path messages sent **async** at high rates, make them **pooled** so delivery recycles
+fixed-size blocks instead of calling `malloc` (the third arg is the per-thread cache size):
+
+```rust
+use actors2::define_pooled_message;
+
+struct MarketData { /* ... */ }
+define_pooled_message!(MarketData, 20, 128);
+```
+
+(Pooling only matters for the async `send` path; `fast_send` passes the message on the stack.)
+
+## 2. Define an actor + its handlers
+
+An actor is a plain struct. Write one handler method per message it accepts, then wire them up
+with `handle_messages!`. Handlers take `&mut self`, the typed message, and an `ActorContext`.
+
+```rust
+use actors2::{handle_messages, ActorContext, ActorRef, Start};
+
+struct PongActor;
+
+impl PongActor {
+    fn on_ping(&mut self, msg: &Ping, ctx: &mut ActorContext) {
+        // reply goes back to the sender (or, under fast_send, is returned to the caller)
+        ctx.reply(Box::new(Pong { count: msg.count }));
+    }
+}
+
+handle_messages!(PongActor,
+    Ping => on_ping,
+);
+```
+
+Optional lifecycle hooks (from the `Actor` trait): `fn init(&mut self, ctx: &mut ActorContext)`
+(runs once before messages) and `fn end(&mut self)` (runs once at shutdown). Unhandled message
+ids are silently ignored (so handling `Start` is optional).
+
+## 3. Send messages: `fast_send` vs `send`
+
+```rust
+// async, fire-and-forget: enqueue into the target's mailbox (its thread runs it).
+target.send(Box::new(Ping { count: 1 }), ctx.self_ref());
+
+// synchronous, on the stack: run the target's handler inline on THIS thread; get the reply.
+let reply: Option<actors2::MsgBox> = target.fast_send(&Ping { count: 1 }, ctx.self_ref());
+
+// pooled async send (recommended for hot-path messages):
+target.send(actors2::MsgBox::pooled(MarketData { /* ... */ }), ctx.self_ref());
+```
+
+- `send(msg, sender)` — `msg` is `impl Into<MsgBox>`, so `Box::new(x)` (heap) or
+  `MsgBox::pooled(x)` both work. `sender` is who to reply to (usually `ctx.self_ref()`).
+- `fast_send(&msg, sender)` — borrows the message on the stack, runs the handler inline, returns
+  the reply (the handler's `ctx.reply(...)`).
+
+**Reentrancy caveat:** the per-actor lock behind `fast_send` is non-reentrant. Do **not** make a
+`fast_send` chain that cycles back into an actor already executing on the same thread (A→A, or
+A→B→A) — it deadlocks. Keep `fast_send` chains acyclic.
+
+## 4. Inside a handler: `ActorContext`
+
+- `ctx.reply(msg)` — reply to the current message (returned to the caller under `fast_send`;
+  delivered to the sender's mailbox under `send`).
+- `ctx.self_ref() -> Option<ActorRef>` — this actor's own handle (pass as the sender of outgoing
+  messages).
+- `ctx.sender() -> Option<ActorRef>` — who sent the current message.
+
+## 5. Run actors with the `Manager`
+
+The `Manager` gives each actor its own OS thread (with optional Linux CPU pinning / RT priority
+via `ThreadConfig`).
+
+```rust
+use actors2::{Manager, ThreadConfig};
+
+fn main() {
+    let mut mgr = Manager::new();
+    let handle = mgr.get_handle();               // for orderly shutdown from inside an actor
+
+    let pong = mgr.manage("Pong", Box::new(PongActor), ThreadConfig::default());
+    let ping = mgr.manage("Ping", Box::new(PingActor { pong, handle }), ThreadConfig::default());
+
+    mgr.init();   // spawn one thread per actor, deliver each a `Start`
+    mgr.run();    // block until an actor calls ManagerHandle::terminate()
+    mgr.end();    // Shutdown all actors and join their threads
+}
+```
+
+- `manage(name, Box::new(actor), cfg) -> ActorRef` — register an actor; the returned `ActorRef`
+  is usable immediately (you can `fast_send` to it before `init`).
+- `ThreadConfig { affinity: Vec<usize>, priority: i32 }` — core pinning + `SCHED_FIFO` priority
+  (Linux only; a no-op elsewhere).
+- `ManagerHandle::terminate()` — from inside any actor, broadcast Shutdown and unblock `run()`.
+- `Manager` also cleans up on drop, so a forgotten `end()` won't leak threads.
+
+## 6. A minimal complete program
+
+See [`examples/ping_pong.rs`](examples/ping_pong.rs) for a runnable two-actor version, and
+[`examples/matching_engine.rs`](examples/matching_engine.rs) for a substantial one (an order-book
+matching engine — its core is a plain, framework-agnostic struct, wrapped by a one-actor
+adapter; see [`MATCHING_ENGINE.md`](MATCHING_ENGINE.md)).
+
+## Gotchas / limits
+
+- Message ids: unique per type, `< 1024`, `< 16` reserved. A duplicate id routes to the wrong
+  handler (debug builds assert; release drops the message).
+- `actors2` is **in-process only** — there is no remote/ZMQ transport or actor registry here.
+- The mailbox is blocking (`Mutex`+`Condvar`); the fast path is `fast_send` (no queue).

--- a/actors/rust2/MATCHING_ENGINE.md
+++ b/actors/rust2/MATCHING_ENGINE.md
@@ -1,0 +1,91 @@
+# Matching engine (example)
+
+A single-actor, per-symbol **spot limit-order-book matching engine** with **price-time (FIFO)
+priority** and first-class partial fills — ships as
+[`examples/matching_engine.rs`](examples/matching_engine.rs).
+
+It demonstrates the intended shape of an exchange matching engine on `actors2`:
+
+- **Core** (`OrderBook`) — a plain, framework-agnostic, **deterministic** struct: `place` /
+  `cancel` / `replace` mutate an in-memory book and **return the resulting events**. This is
+  where correctness lives (see the tests).
+- **Actor** (`MatchingEngine`) — a thin adapter that owns the book (its mailbox makes it the
+  deterministic **single writer** for its symbol) and routes each event to the right `ActorRef`.
+
+## Run it
+
+```sh
+cargo test  --example matching_engine                    # 15 tests
+cargo run   --example matching_engine                    # demo: build a book, cross an order, cancel, replace
+cargo run --release --example matching_engine -- bench   # throughput benchmark
+```
+
+In-memory only; no server/container. To run as a standalone binary, copy the single file into a
+`cargo new` project's `src/main.rs` with `actors2` as a dependency.
+
+## Messages
+
+**Inbound (order entry)** — modelled on FIX/iLink; integer prices/quantities:
+
+| Message | Fields | Meaning |
+|---|---|---|
+| `PlaceOrder` | `order_id, side, price, qty` | new limit order: match what crosses, rest the remainder |
+| `CancelOrder` | `order_id` | remove a resting order |
+| `ReplaceOrder` | `order_id, new_price, new_qty` | cancel-replace (re-queues at tail → loses time priority) |
+
+**Outbound (execution reports)** — `Ack`, `FillMsg` (emitted to **both** sides of a trade, at the
+maker's price), `Canceled`, `Replaced`, `Rejected`, `BboUpdate`. On the async path these are
+**pooled** (`MsgBox::pooled`); inbound orders arrive via `fast_send` (on the stack). Rejects (bad
+price/qty, unknown/duplicate id) never panic — they emit `Rejected` and leave the book unchanged.
+
+## Data structure (O(1) hot ops)
+
+Carried from the C++ `OB`/`OrderQ` design:
+
+- price → **level** in a `BTreeMap` (best bid = max key, best ask = min key; O(log L));
+- each level is an **intrusive doubly-linked FIFO list** over a shared **slab** of order nodes;
+- a global `order_id → node` index.
+
+So **rest, match-at-head, cancel, and replace are all O(1)** (no linear scan, no mid-array
+shift), and best-of-book aggregate size is O(1) via a per-level running total. Integer
+prices/qty give exact partial-fill accounting.
+
+## Matching algorithm (price-time FIFO)
+
+Price priority (best price first) then time priority (earliest at a level). A marketable order
+sweeps opposite levels generating fills **at the maker's price** (taker price improvement),
+resting any non-marketable remainder. Cancel unlinks in O(1). Cancel-replace = remove old (emit
+`Replaced`) + place new (re-queues at the tail, may immediately match).
+
+## Tests (15)
+
+Run `cargo test --example matching_engine`:
+
+- **Core** — price-time priority, partial fill, price improvement, cancel, cancel-replace loses
+  priority, reject cases.
+- **Book integrity** — a 20k-op random `place`/`cancel`/`replace` fuzz that asserts invariants
+  after **every** op (in particular: the book is **never left crossed**; index ↔ node ↔ level
+  totals stay consistent), plus an aggressive multi-level sweep.
+- **Actor-level** — drive the `MatchingEngine` actor end-to-end and assert the exact
+  execution-report sequence.
+
+## Performance (measured, release, single core, unpinned dev box)
+
+| Workload | ns/op | throughput |
+|---|---|---|
+| insert (rest, no cross), book at 2M live orders | ~165 ns | ~6.1 M/s |
+| match (each order fully crosses → a trade) | ~115 ns | ~8.7 M/s |
+| cancel from a 1M-deep single level (reverse order) | ~115 ns | ~8.7 M/s |
+
+A single core comfortably clears a 3M msg/s target; throughput scales by running one engine
+actor per symbol across cores. (Matching only — excludes network / serialization at the edges.)
+
+## Design origin & further reading
+
+Data-structure design carried (design, not code) from the C++ `OB` actor in this repo:
+`../../frame_kaspr/include/frame/ob/act/OB.hpp`, `.../ob/OrderQ.hpp`, `.../ob/Order.hpp`,
+`../../frame_kaspr/src/OB.cpp`. That `OB` is a feed-driven book *reconstructor*; here we reuse its
+structures and drive them from **order entry** with explicit crossing.
+
+- The Actor Model for Low-Latency Software —
+  <https://vincentmayeski.substack.com/p/the-actor-model-for-low-latency-software>

--- a/actors/rust2/README.md
+++ b/actors/rust2/README.md
@@ -1,0 +1,96 @@
+# actors2 — a performance-first Rust actor framework
+
+`actors2` is a Rust port of the C++ **Kaspar** actor framework (`../cpp`), tuned for
+low-latency / HFT-style workloads. It is **in-process and shared-nothing**: actors own their
+state and communicate only by messages, with two message paths that let you tune latency by
+configuration rather than by rewriting code.
+
+> **Looking for the matching engine?** It ships as an example:
+> [`examples/matching_engine.rs`](examples/matching_engine.rs). See
+> [`MATCHING_ENGINE.md`](MATCHING_ENGINE.md).
+
+## Quickstart
+
+```sh
+# from this directory (actors/rust2)
+cargo test                                   # framework unit/integration tests
+cargo run   --example matching_engine        # matching-engine demo (build book, cross, cancel, replace)
+cargo test  --example matching_engine        # the engine's 15 tests
+cargo run --release --example matching_engine -- bench   # engine throughput benchmark
+cargo run   --example ping_pong              # async actor round-trip
+cargo run --release --example bench_fast_send   # fast_send latency
+cargo run --release --example bench_pool        # pool vs heap allocation
+```
+
+Needs a stable Rust toolchain (`rustc`/`cargo`, e.g. via [rustup](https://rustup.rs)). No
+server, container, or database — everything is in-memory.
+
+## The core idea: two message paths
+
+| | `fast_send` (hot path) | `send` (cold path) |
+|---|---|---|
+| Semantics | runs the target's handler **inline on the caller's thread**, message **on the stack** | **enqueues** into the target's mailbox; the target's own thread runs it |
+| Cost | ~a function call (~20 ns) | ~microseconds (thread hop + condvar wakeup) |
+| Use for | synchronous request/reply on the latency-critical chain | async, decoupled fan-out |
+
+Collapse the hot chain onto one (optionally pinned) thread with `fast_send`; push everything
+off-path (fan-out, logging, I/O) onto other threads with `send`.
+
+## What's in the box (and how it maps to the C++)
+
+| Primitive | What it does | C++ origin |
+|---|---|---|
+| `fast_send` | on-stack, inline, any actor → any actor (per-actor lock) | `Actor::fast_send` |
+| integer message IDs + `handle_messages!` | O(1) dispatch via a flat table | `handler_cache` |
+| `BQueue` | preallocated ring + deque overflow + condvar mailbox | `BQueue` |
+| object pool (`define_pooled_message!`, `MsgBox::pooled`) | per-type block recycling, no malloc on the hot path | `MemoryPool` |
+| `Manager` | thread-per-actor + Linux CPU affinity / `SCHED_FIFO` | `Manager` |
+
+Release profile is tuned (`lto`, `codegen-units=1`, `panic=abort`); add
+`RUSTFLAGS="-C target-cpu=native"` for the last few percent.
+
+## What is **not** ported (be aware)
+
+This is a fresh, focused port — it is **not** the full C++/`m2_kspr` framework:
+
+- **No remote transport / registry / coordination** — `actors2` is **in-process only** (no ZMQ,
+  no `GlobalRegistry`, no cross-process actor lookup). Those live in the private multi-language
+  build, not here.
+- **No Groups** (many actors sharing one thread), **no timer subsystem**, **no console/monitoring**
+  — deferred.
+- **No lock-free queue yet** — the mailbox is `Mutex`+`Condvar` (as in C++); a lock-free ring
+  (`crossbeam`) is a possible future step.
+
+## Layout
+
+```
+actors/rust2
+├── src/          # the framework crate (actors2)
+│   ├── actor.rs      # Actor trait, ActorContext, fast_send, dispatch (handle_messages!)
+│   ├── message.rs    # Message trait + define_message! (integer ids)
+│   ├── pool.rs       # per-type object pool + define_pooled_message!
+│   ├── owner.rs      # MsgBox (heap-or-pooled message owner)
+│   ├── queue.rs      # BQueue mailbox
+│   ├── manager.rs    # thread-per-actor Manager, affinity/priority
+│   └── messages.rs   # framework messages (Start, Shutdown)
+├── examples/
+│   ├── matching_engine.rs   # <-- the order-book matching engine
+│   ├── ping_pong.rs / bench_fast_send.rs / bench_pool.rs
+└── tests/        # queue / pool / owner / manager integration tests
+```
+
+See [`DEVELOPER_GUIDE.md`](DEVELOPER_GUIDE.md) to write your own actor, and
+[`MATCHING_ENGINE.md`](MATCHING_ENGINE.md) for the engine design.
+
+## Further reading
+
+Background on the design this port is based on (author's write-ups):
+
+- **The Actor Model for Low-Latency Software** —
+  <https://vincentmayeski.substack.com/p/the-actor-model-for-low-latency-software>
+- **A High-Performance Mailbox in the Kaspar Actor Framework** (the `BQueue` design) —
+  <https://vincentmayeski.substack.com/p/high-performance-mailbox-in-the-kaspar>
+- **A Custom Memory Allocator for the Kaspar Actor Framework** (the object pool) —
+  <https://vincentmayeski.substack.com/p/a-custom-memory-allocator-for-the>
+
+Licensed MIT (see repo root).


### PR DESCRIPTION
Documentation so a reader landing in `actors/rust2/` can navigate it (the full system-design writeup lives outside the repo).

- **README.md** — what `actors2` is, quickstart, the `fast_send` vs `send` model, the primitives and their C++ origin, and an honest **"what's NOT ported"** (no remote/registry, no groups/timers, no lock-free queue yet). Links the author's Substack write-ups.
- **DEVELOPER_GUIDE.md** — written to the **actual `rust2` API** (the old crate's guide describes a different, channel/ZMQ-based API): `define_message!`/`define_pooled_message!`, `handle_messages!`, `fast_send` vs `send`, `ActorContext`, `Manager`/`ThreadConfig`, pooling, and the `fast_send` reentrancy caveat.
- **MATCHING_ENGINE.md** — self-contained engine writeup: inbound/outbound messages, the O(1) indexed-slab data structure, the algorithm, the 15 tests, and the perf numbers.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive guide for developing with the Rust actor framework.
  * Documented actor messaging, lifecycle management, asynchronous and synchronous communication, configuration, shutdown, and framework limitations.
  * Added a matching-engine example covering order matching, cancellations, replacements, reporting, and performance characteristics.
  * Added a framework README with quickstart instructions, core concepts, tuning guidance, repository information, and licensing details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->