### PR TITLE
README: link the C++/Rust actor-systems article

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ The actor framework provides the concurrency model for the entire system:
 - **Rust port** — [`actors/rust2`](actors/rust2) (`actors2`) is a from-scratch Rust port of the actor core (on-stack `fast_send`, integer-ID O(1) dispatch, `BQueue`, object pool). It is in-process only (no ZMQ/registry/groups yet) and ships a **matching engine** as an example — see its [README](actors/rust2/README.md) and [DEVELOPER_GUIDE](actors/rust2/DEVELOPER_GUIDE.md).
 
 The design behind the framework is written up here:
+[**Low-Latency Actor Systems in C++ and Rust**](https://vincentmayeski.substack.com/p/low-latency-actor-systems-in-c-and)
+(building this framework in both languages),
 [**The Actor Model for Low-Latency Software**](https://vincentmayeski.substack.com/p/the-actor-model-for-low-latency-software),
 [**A High-Performance Mailbox**](https://vincentmayeski.substack.com/p/high-performance-mailbox-in-the-kaspar)
 (the `BQueue`), and
@@ -246,6 +248,7 @@ kaspr {
 
 Deep-dives on the design behind Kaspar (author's Substack — [vincentmayeski.substack.com](https://vincentmayeski.substack.com)):
 
+- [**Low-Latency Actor Systems in C++ and Rust**](https://vincentmayeski.substack.com/p/low-latency-actor-systems-in-c-and) — building the same actor framework in both languages: this repo's C++ core and its Rust port (`actors/rust2`), and what carries over vs. what the borrow checker changes.
 - [**The Actor Model for Low-Latency Software**](https://vincentmayeski.substack.com/p/the-actor-model-for-low-latency-software) — a concurrency model invented for single-CPU machines turned out to be the right one for multicore.
 - [**A High-Performance Mailbox in the Kaspar C++ Actor System**](https://vincentmayeski.substack.com/p/high-performance-mailbox-in-the-kaspar) — ring buffers are great until they overflow (the `BQueue` design).
 - [**A Custom Memory Allocator for the Kaspar Actor System Gives 10× Improvement**](https://vincentmayeski.substack.com/p/a-custom-memory-allocator-for-the) — when you know the size at compile time, almost everything an allocator does becomes unnecessary (the object pool).


### PR DESCRIPTION
Adds the published Substack post *Low-Latency Actor Systems in C++ and Rust* to the README (Actor Framework write-ups + Writing section lead).