### PR TITLE
interop example: full C++/Rust fast_send matrix

### DIFF
--- a/actors/rust/interop/example/README.md
+++ b/actors/rust/interop/example/README.md
@@ -52,18 +52,21 @@ cargo run --release` (and `BOOST_INC_DIR=… bash cpp/build_cpp.sh`).
 
 ## What it measures
 
-`fast_send` with no reply — the pure cross-FFI dispatch into a C++ handler — versus the same call to
-a Rust actor. Representative (Apple Silicon, single thread, release):
+`fast_send` with no reply, across every sender/receiver combination of C++ and Rust actors in one
+process. Representative (Apple Silicon, single thread, release, ns/call):
 
 ```
-fast_send, no reply, 5,000,000 calls:
-  Rust -> Rust  (same language):     ~15 ns/call
-  Rust -> C++   (over FFI bridge):   ~71 ns/call   (~4.7x, +56 ns)
+                    ->  Rust receiver       ->  C++ receiver
+  Rust sender          ~15  (same lang)       ~70  (over FFI)
+  C++  sender          ~46  (over FFI)        ~13  (same lang)
 ```
 
-The ~56 ns is the boundary cost: outbound match + `to_c` copy + the `extern "C"` call + the C++
-`get_actor_by_name` lookup + `from_c` + the C++ dispatch. (The per-call name lookup is part of it — a
-latency-sensitive caller would cache the `ActorRef::Cpp` once, which this example does.)
+Same-language dispatch is ~13–15 ns. Crossing the boundary adds the marshalling (`to_c`/`from_c`
+copies), the `extern "C"` call, the per-call name lookup, and the receiving-side dispatch. The two FFI
+directions are not symmetric: Rust→C++ (~70 ns) pays for the C++ `get_actor_by_name` (a `std::string`
+build + lookup + `ActorRef` return) each call, while C++→Rust (~46 ns) goes through the Rust inbound
+resolver + `catch_unwind` guard. A latency-sensitive caller caches the resolved reference (this
+example holds the `ActorRef::Cpp` and reuses it) rather than resolving by name every time.
 
-Note: cross-boundary **replies** are not wired yet (a `fast_send` to a C++ actor returns `None`), so
-this measures the one-way Rust→C++ call.
+Note: cross-boundary **replies** are not wired yet (a cross-language `fast_send` returns nothing), so
+this measures one-way calls.

--- a/actors/rust/interop/example/cpp/hybrid_cpp.cpp
+++ b/actors/rust/interop/example/cpp/hybrid_cpp.cpp
@@ -1,13 +1,17 @@
 // C++ side of the hybrid interop benchmark: a real C++ actor that handles the
-// interop msg::Ping, registered by name so the generated bridge can reach it.
+// interop msg::Ping, registered by name so the generated bridge can reach it,
+// plus the C++-driven half of the benchmark (C++->C++ and C++->Rust).
+#include <chrono>
 #include <cstring>
 
 #include "actors/Actor.hpp"
 #include "actors/act/Manager.hpp"
-#include "InteropMessages.hpp"   // msg::Ping (generated)
+#include "InteropMessages.hpp"   // msg::Ping, ::Ping (generated)
 #include "CppActorBridge.hpp"    // cpp_actor_init
+#include "RustActorIF.hpp"       // rust_actor_fast_send (into Rust)
 
 using namespace actors;
+using clk = std::chrono::steady_clock;
 
 struct PongC : Actor {
     long count = 0;
@@ -15,7 +19,7 @@ struct PongC : Actor {
         std::strncpy(name, "cpp_pong", sizeof(name));
         MESSAGE_HANDLER(msg::Ping, on_ping);
     }
-    // Trivial work, no reply — measures the cross-FFI dispatch into a C++ handler.
+    // Trivial work, no reply — measures the dispatch into a C++ handler.
     void on_ping(const msg::Ping* m) { count += m->count; }
 };
 
@@ -27,4 +31,27 @@ extern "C" void hybrid_setup() {
     g_pong = new PongC();
     g_mgr->add_to_manage_q(g_pong);   // registers "cpp_pong" by name (no thread needed for fast_send)
     cpp_actor_init(g_mgr);            // let the bridge find C++ actors via this Manager
+}
+
+static double ns_per(long n, clk::time_point t0) {
+    return std::chrono::duration<double, std::nano>(clk::now() - t0).count() / (double)n;
+}
+
+// The C++-driven half: C++ -> C++ (same language) and C++ -> Rust (over the bridge,
+// into a Rust actor named "rust_pong" that the Rust side has registered).
+extern "C" void run_cpp_bench(long n, double* cpp_cpp_ns, double* cpp_rust_ns) {
+    // C++ -> C++ : fast_send to the local C++ actor.
+    {
+        for (long i = 0; i < 200000; i++) { msg::Ping p; p.count = (int)i; auto r = g_pong->fast_send(&p, nullptr); (void)r; }
+        auto t0 = clk::now();
+        for (long i = 0; i < n; i++) { msg::Ping p; p.count = (int)i; auto r = g_pong->fast_send(&p, nullptr); (void)r; }
+        *cpp_cpp_ns = ns_per(n, t0);
+    }
+    // C++ -> Rust : marshal a POD and call into the Rust actor over the FFI.
+    {
+        for (long i = 0; i < 200000; i++) { ::Ping c; c.count = (int)i; rust_actor_fast_send("rust_pong", nullptr, 400, &c); }
+        auto t0 = clk::now();
+        for (long i = 0; i < n; i++) { ::Ping c; c.count = (int)i; rust_actor_fast_send("rust_pong", nullptr, 400, &c); }
+        *cpp_rust_ns = ns_per(n, t0);
+    }
 }

--- a/actors/rust/interop/example/src/main.rs
+++ b/actors/rust/interop/example/src/main.rs
@@ -1,19 +1,22 @@
-// Hybrid C++/Rust interop benchmark: a Rust actor fast_sends to a real C++ actor
-// across the C-ABI FFI bridge, in one process. Measures the cross-language cost,
-// alongside a same-language (Rust->Rust) baseline in the same binary.
+// Hybrid C++/Rust interop benchmark. Measures fast_send (no reply) across the
+// full 2x2 matrix — every sender/receiver combination of C++ and Rust actors, in
+// one process:
+//     Rust -> Rust   (same language)       Rust -> C++   (over the FFI bridge)
+//     C++  -> Rust   (over the FFI bridge)  C++  -> C++   (same language)
 //
-// The C++ side (cpp/hybrid_cpp.cpp) sets up a C++ Manager + a msg::Ping-handling
-// actor named "cpp_pong" and calls cpp_actor_init(). The Rust side resolves it as
-// an ActorRef::Cpp and calls fast_send in a loop.
+// The C++ side (cpp/hybrid_cpp.cpp) provides the C++ actor "cpp_pong" and the
+// C++-driven half; the Rust side provides "rust_pong" and the Rust-driven half.
 
 use std::hint::black_box;
 use std::time::Instant;
 
 use actors::interop::generated::{register, Ping};
-use actors::{handle_messages, ActorContext, Manager, ThreadConfig};
+use actors::interop::register_local_lookup;
+use actors::{handle_messages, ActorContext, ActorRef, Manager, ThreadConfig};
 
 extern "C" {
-    fn hybrid_setup(); // implemented in cpp/hybrid_cpp.cpp
+    fn hybrid_setup(); // C++: Manager + "cpp_pong" + cpp_actor_init
+    fn run_cpp_bench(n: i64, cpp_cpp_ns: *mut f64, cpp_rust_ns: *mut f64); // C++-driven half
 }
 
 // A same-language Rust receiver: trivial work, no reply — mirrors the C++ actor.
@@ -27,7 +30,7 @@ impl RustPong {
 }
 handle_messages!(RustPong, Ping => on_ping);
 
-fn time_loop(n: i32, r: &actors::ActorRef) -> f64 {
+fn time_loop(n: i32, r: &ActorRef) -> f64 {
     for i in 0..200_000i32 { black_box(r.fast_send(black_box(&Ping { count: i }), None)); }
     let t = Instant::now();
     for i in 0..n { black_box(r.fast_send(black_box(&Ping { count: i }), None)); }
@@ -37,21 +40,28 @@ fn time_loop(n: i32, r: &actors::ActorRef) -> f64 {
 fn main() {
     let n: i32 = 5_000_000;
 
-    // Baseline: Rust -> Rust fast_send (same process, same language, no reply).
+    // Rust manager + a Rust actor "rust_pong".
     let mut lmgr = Manager::new();
     let rust_pong = lmgr.manage("rust_pong", Box::new(RustPong { acc: 0 }), ThreadConfig::default());
-    let base = time_loop(n, &rust_pong);
 
-    // Interop: Rust -> C++ fast_send across the C-ABI bridge.
-    unsafe { hybrid_setup(); }        // C++: Manager + "cpp_pong" actor + cpp_actor_init
-    register();                        // install the generated inbound dispatcher + C++ resolver
-    let mgr = Manager::new();
-    let cpp = mgr.get_ref("cpp_pong", "rust_driver").expect("cpp_pong not resolvable over FFI");
-    let ffi = time_loop(n, &cpp);
+    // Wire the interop both directions.
+    unsafe { hybrid_setup(); }                 // C++ side: Manager + "cpp_pong" + cpp_actor_init
+    register();                                 // install generated inbound dispatch + C++ resolver
+    let handle = lmgr.get_handle();
+    register_local_lookup(move |name| handle.get_ref_local(name)); // so C++ -> Rust finds "rust_pong"
+
+    // Rust-driven half.
+    let rr = time_loop(n, &rust_pong); // Rust -> Rust
+    let cpp = lmgr.get_ref("cpp_pong", "rust_driver").expect("cpp_pong not resolvable over FFI");
+    let rc = time_loop(n, &cpp); // Rust -> C++ (over FFI)
+
+    // C++-driven half (timed in C++).
+    let (mut cc, mut cr) = (0.0f64, 0.0f64);
+    unsafe { run_cpp_bench(n as i64, &mut cc, &mut cr); } // C++ -> C++, C++ -> Rust
 
     println!();
-    println!("fast_send, no reply, {} calls (Apple Silicon, single thread):", n);
-    println!("  Rust -> Rust  (same language):   {:6.1} ns/call", base);
-    println!("  Rust -> C++   (over FFI bridge): {:6.1} ns/call   ({:.1}x, +{:.0} ns)",
-             ffi, ffi / base, ffi - base);
+    println!("fast_send, no reply, {n} calls (Apple Silicon, single thread, ns/call):");
+    println!("                    ->  Rust receiver       ->  C++ receiver");
+    println!("  Rust sender          {rr:5.1}  (same lang)      {rc:5.1}  (over FFI)");
+    println!("  C++  sender          {cr:5.1}  (over FFI)       {cc:5.1}  (same lang)");
 }


### PR DESCRIPTION
Extends the hybrid interop benchmark to **all four** sender/receiver combinations in one process (was only the two Rust-driven ones):

| sender \ receiver | Rust | C++ |
|---|---:|---:|
| **Rust** | ~15 ns (same lang) | ~70 ns (FFI) |
| **C++** | ~46 ns (FFI) | ~13 ns (same lang) |

- C++ side gains `run_cpp_bench()` (C++→C++ + C++→Rust via `rust_actor_fast_send`, timed in C++).
- Rust side registers a local-lookup so C++→Rust resolves `rust_pong`, and prints the matrix.
- The two FFI directions are **asymmetric**: Rust→C++ pays for the C++ `get_actor_by_name` per call; C++→Rust goes through the Rust inbound resolver + `catch_unwind`.

Apple Silicon, single thread, release, `fast_send` no reply, 5M calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)