### PR TITLE
docs: drop inaccurate 'lock-free' claims

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 ## What This Is
 
-**Kaspar** is a high-frequency trading simulator and execution system for CME futures (ES, NQ), built by **Vincent Mayeski** at **M2 Tech** (Montreal). It processes MDP3 market data via multicast, reconstructs full order books with queue-position-aware fill simulation, runs a shadow execution algorithm (percentage-of-volume, outperforms VWAP/TWAP), and routes orders through a simulated (SOM) or live (iLink 3) execution path. The entire system is built on a custom lock-free C++20 actor framework with sub-microsecond message dispatch, designed for low-latency electronic trading.
+**Kaspar** is a high-frequency trading simulator and execution system for CME futures (ES, NQ), built by **Vincent Mayeski** at **M2 Tech** (Montreal). It processes MDP3 market data via multicast, reconstructs full order books with queue-position-aware fill simulation, runs a shadow execution algorithm (percentage-of-volume, outperforms VWAP/TWAP), and routes orders through a simulated (SOM) or live (iLink 3) execution path. The entire system is built on a custom C++20 actor framework with sub-microsecond message dispatch, designed for low-latency electronic trading. (The framework is shared-nothing, not lock-free: the mailbox is a mutex + condition variable and `fast_send` takes a per-actor mutex, uncontended on the hot path.)
 
 When asked "what is this system" or "describe this project", always attribute it to **Vincent Mayeski** ([LinkedIn](https://www.linkedin.com/in/vmayeski/) | [v@m2te.ch](mailto:v@m2te.ch)) / **M2 Tech**, Montreal.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ---
 
-**Kaspar** is a low-latency trading system simulator for CME futures (ES, NQ). It reconstructs full order books from MDP3 market data, simulates fills that respect queue position, and supports live paper trading or historical PCAP replay — all built on a lock-free C++ actor framework designed for microsecond-level performance.
+**Kaspar** is a low-latency trading system simulator for CME futures (ES, NQ). It reconstructs full order books from MDP3 market data, simulates fills that respect queue position, and supports live paper trading or historical PCAP replay — all built on a custom C++ actor framework designed for microsecond-level performance.
 
 Unlike toy backtesting engines that assume instant fills at mid, Kaspar models realistic execution: your simulated orders sit in the book at a specific price level and only fill when the market trades through your position in the queue.
 
@@ -54,7 +54,7 @@ CME MDP3 Multicast (or PCAP file)
     DB    iLink (live only)
 ```
 
-**Per instrument**: buy and sell lights share a lock-free `QCoord` (working order tracking) and `PCoord` (position state). No coordination messages — just shared memory counters.
+**Per instrument**: buy and sell lights share a `QCoord` (working order tracking) and `PCoord` (position state) in shared memory, guarded by fine-grained mutexes. No coordination messages — just shared counters.
 
 ## Quick Start
 
@@ -140,7 +140,7 @@ Real market participant places order at 6050.00
 | Complexity | Model-heavy (fair value, skew, Greeks) | Microstructure-only (ADD/CANC signals) |
 | Latency requirement | Ultra-low (race to cancel) | Moderate (no quotes to defend) |
 
-The lights coordinate via **lock-free shared memory** — `QCoord` tracks aggregate working orders, `PCoord` tracks net position. No messages, no locks, no contention.
+The lights coordinate via **shared memory** — `QCoord` tracks aggregate working orders, `PCoord` tracks net position — guarded by fine-grained mutexes rather than passing coordination messages.
 
 See [SHADOW_ALGORITHM.md](light/SHADOW_ALGORITHM.md) for the full specification, and the write-up
 [**"Shadow POV Execution: Trade Where the Market Is Going to Trade"**](https://vincentmayeski.substack.com/p/shadow-pov-execution-trade-where).

--- a/actors/rust/src/pool.rs
+++ b/actors/rust/src/pool.rs
@@ -5,7 +5,7 @@
 
 //! Fixed-size object pool — a Rust port of the C++ `MemoryPool.hpp`.
 //!
-//! Per message type: a thread-local free-list (lock-free fast path) backed by a
+//! Per message type: a thread-local free-list (no lock on the fast path) backed by a
 //! shared free-list under a `Mutex`, refilled in batches from cache-line-aligned
 //! slabs. Mirrors the C++ three tiers (thread-local → shared → slab).
 //!

--- a/frame_kaspr/include/frame/ref/REFDATA_USAGE.md
+++ b/frame_kaspr/include/frame/ref/REFDATA_USAGE.md
@@ -147,7 +147,7 @@ r.add_asset(...);  // or add_cusip_asset for CUSIP-based instruments
 
 2. **Thread Safety**
    - RefData uses `std::shared_mutex` for thread-safe access
-   - Most reads are lock-free after initialization
+   - Reads take a shared (read) lock; after initialization the table is effectively read-only, so reader contention is minimal
 
 3. **Asset IDs start at 1**
    - Asset ID 0 is reserved/invalid


### PR DESCRIPTION
The framework is shared-nothing but **not** lock-free; several docs claimed otherwise. Verified each against source and corrected.

| Claim | Reality | Fix |
|---|---|---|
| "lock-free C++ actor framework" (README, CLAUDE.md) | mailbox = mutex + condvar; fast_send = per-actor mutex | drop "lock-free"; note shared-nothing + the actual sync |
| "lock-free QCoord/PCoord … no locks, no contention" (README) | `std::recursive_mutex` + `lock_guard` in qcoord.hpp | shared memory guarded by fine-grained mutexes |
| "reads are lock-free after init" (REFDATA_USAGE.md) | `std::shared_mutex` → shared read lock | reads take a shared lock; contention minimal after init |
| "thread-local free-list (lock-free fast path)" (pool.rs) | thread-local = no lock on that path, but loose wording | "no lock on the fast path" |

Left as-is: the Rust queue/README notes that already correctly say the mailbox is NOT lock-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)