### PR TITLE
Experimental: batch-drain + ShardedBQueue/LockFreeMPSC mailboxes (not for merge yet)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ actors/cpp/examples/ping_pong
 actors/cpp/examples/remote_ping
 actors/cpp/examples/remote_pong
 actors/cpp/tests/**/test_*
+!actors/cpp/tests/**/test_*.cpp
+!actors/cpp/tests/**/test_*.hpp
+!actors/cpp/tests/**/test_*.h
 actors/cpp/src/coordination/group_manager_main
 actors/cpp/src/registry/global_registry_main
 

--- a/actors/README.md
+++ b/actors/README.md
@@ -23,9 +23,17 @@ Two implementations live here, plus an in-process bridge between them:
 |------|---------|
 | `Actor.hpp` | Base actor class with message dispatch |
 | `Message.hpp` | Base message class with type-safe routing |
-| `Queue.hpp` / `BQueue.hpp` | Message queues (mailbox) |
+| `Queue.hpp` | Mailbox interface (`push` / `pop` / `pop_batch`) |
+| `BQueue.hpp` | Default mailbox: blocking mutex + condvar, ring + overflow |
+| `ShardedBQueue.hpp` | Sharded (N-lane) mailbox for high-fan-in actors — cuts tail jitter |
+| `LockFreeMPSC.hpp` | Lock-free (Vyukov) mailbox for few-producer, latency-critical actors |
 | `MemoryPool.hpp` | Per-message-type pool allocator |
 | `ActorRef.hpp` | Lightweight actor reference handle |
+
+**Choosing a mailbox per actor:** an actor defaults to `BQueue`, but can install a
+`ShardedBQueue` or `LockFreeMPSC` via the `Actor(Queue*)` constructor. Which to use
+depends on producer count — see **[`cpp/MAILBOXES.md`](cpp/MAILBOXES.md)** for the
+selection matrix, measurements, and code.
 
 ## Actor types (`cpp/include/actors/act/`)
 
@@ -45,3 +53,11 @@ a single process. There is no remote/cross-process actor transport.
 cd actors/cpp && KSPRPROJ=~/m2_kaspar make      # C++
 cd actors/rust && cargo test                     # Rust port
 ```
+
+## Writeups
+
+Design notes and measurements behind the mailbox internals:
+
+- [How Message Batching More Than Doubles Actor Model Throughput](https://vincentmayeski.substack.com/p/how-message-batching-more-than-doubles) — batch drain + the message pool (2.46×).
+- [Medians Lie, Tails Kill: Why Kaspar Shards Mailbox Locks](https://vincentmayeski.substack.com/p/medians-lie-tails-kill-why-kaspar) — per-actor mailboxes and tail-latency jitter.
+- [The Lock-Free Illusion: Why CAS Storms Kill Actor Queues Under Contention](https://vincentmayeski.substack.com/p/the-lock-free-illusion-why-cas-storms) — when lock-free wins, and when it backfires.

--- a/actors/cpp/Actor.cpp
+++ b/actors/cpp/Actor.cpp
@@ -149,20 +149,38 @@ void Actor::operator()() noexcept
   std::cerr << endl << get_name() << " tid: " << tid << endl;
   init();
 
+  // Lever 1: drain the whole mailbox in one lock (msgq->pop_batch). Lever 2:
+  // take the per-actor fast_send_mutex ONCE for the whole batch instead of per
+  // message (process_message_internal locks it per call, so the body is inlined
+  // here). fast_send shares this mutex, so a fast_send to this actor waits for
+  // the batch to finish — the intended throughput/latency tradeoff.
+  std::vector<const Message *> batch;
   while (true) {
-    auto r = msgq->pop();
-    auto *m = std::get<0>(r);
-    auto last = std::get<1>(r);
-    m->last = last;
-    reply_to = m->sender;
+    msgq->pop_batch(batch);
+    bool stop = false;
+    {
+      std::lock_guard<std::mutex> lock(fast_send_mutex);
+      for (size_t i = 0; i < batch.size(); ++i) {
+        const Message *m = batch[i];
+        m->last = (i + 1 == batch.size()); // last == queue was drained empty
+        reply_to = m->sender;
+        bool is_shutdown = m->get_message_id() == 5;
 
-    bool is_shutdown = m->get_message_id() == 5;
+        msg_cnt++;
+        using_fast_send = false;
+        bool called = call_handler(m);
+        if (!called)
+          process_message(m);
+        delete m;
 
-    process_message_internal(m);
-
-    if (is_shutdown || terminated) {
-      break;
+        if (is_shutdown || terminated) {
+          stop = true;
+          break;
+        }
+      }
     }
+    if (stop)
+      break;
   }
 
   terminated = true;

--- a/actors/cpp/Actor.cpp
+++ b/actors/cpp/Actor.cpp
@@ -179,6 +179,13 @@ void Actor::operator()() noexcept
 
         if (is_shutdown || terminated) {
           stop = true;
+          // We drained the whole mailbox into `batch` but are terminating now.
+          // Delete the messages we won't process, or they leak (the batch vector
+          // only drops the pointers). Old one-at-a-time pop() never pre-fetched
+          // these, so the batch change would otherwise leak every co-drained
+          // message that followed a shutdown/terminate.
+          for (size_t k = i + 1; k < batch.size(); ++k)
+            delete batch[k];
           break;
         }
       }

--- a/actors/cpp/Actor.cpp
+++ b/actors/cpp/Actor.cpp
@@ -36,9 +36,13 @@ Actor::~Actor()
   delete msgq;
 }
 
-Actor::Actor()
+Actor::Actor() : Actor(new BQueue<const Message *>(ACTOR_BQUEUE_SIZE))
 {
-  msgq = new BQueue<const Message *>(ACTOR_BQUEUE_SIZE);
+}
+
+Actor::Actor(Queue<const Message *> *mailbox)
+{
+  msgq = mailbox;
   handler_cache.resize(ACTOR_HANDLER_CACHE_SIZE, nullptr);
   dont_have_handler.resize(ACTOR_HANDLER_CACHE_SIZE, false);
 

--- a/actors/cpp/MAILBOXES.md
+++ b/actors/cpp/MAILBOXES.md
@@ -1,0 +1,110 @@
+<!--
+    Copyright (c) 2026 Vincent Mayeski / M2 Tech (16425640 Canada Inc.).
+    Contact: v@m2te.ch | https://www.linkedin.com/in/vmayeski/
+    Licensed under the MIT License. See LICENSE file in the project root.
+-->
+
+# Choosing an Actor Mailbox
+
+Every actor owns a mailbox — a queue that other threads push messages into and the
+actor's own thread drains. All mailboxes implement one interface, `Queue<T>`
+(`Queue.hpp`), so they're interchangeable. Which one an actor uses is a per-actor
+decision driven almost entirely by **how many threads produce into it**, because that
+is what sets tail-latency jitter.
+
+## The three mailboxes
+
+| Mailbox | Header | Optimizes for |
+|---|---|---|
+| `BQueue` | `BQueue.hpp` | The default. One mutex + condvar; a fixed ring with an unbounded overflow deque. Best median; tails under high contention because a losing producer parks. |
+| `ShardedBQueue` | `ShardedBQueue.hpp` | Many producers (high fan-in). N mutex lanes, round-robin push, round-robin-merge drain. Spreads contention across lanes → lowest p99 under load. |
+| `LockFreeMPSC` | `LockFreeMPSC.hpp` | Few producers, latency-critical. Bounded Vyukov ring, park-free push. Flat sub-µs tail when contention is low; degrades under high fan-in (CAS-retry storms). |
+
+## Selection matrix
+
+| Your actor's producers | Use | Why |
+|---|---|---|
+| 1 producer | `BQueue` or `LockFreeMPSC` | Both ~42 ns; no contention to fix. |
+| Few (2–4), latency-critical | **`LockFreeMPSC`** | Park-free → flat, sub-microsecond tail. |
+| Many (high fan-in) | **`ShardedBQueue`** | Fewest threads per sync point → lowest p99. |
+| Many *and* latency-critical | Sharded lock-free (roadmap) | N lock-free lanes → few producers per CAS line. |
+
+Rule of thumb: **shard first, go lock-free second.** A single lock-free queue becomes
+a hotspot the moment its producer count climbs — the CAS loop starts retrying and
+tails just like a mutex.
+
+## Measurements
+
+Latency of a single `push()` under load, ns (Apple Silicon, `-O3`, median of
+interleaved runs). Jitter lives in the tail, so read p99/p99.9, not the median.
+
+**High contention (8 producers into one mailbox):**
+
+| Mechanism | p50 | p99 | p99.9 |
+|---|---:|---:|---:|
+| `BQueue` | 42 | ~35 µs | ~79 µs |
+| `ShardedBQueue` (8 lanes) | ~420 | **~7.4 µs** | ~75 µs |
+| `LockFreeMPSC` | ~875 | ~38 µs | ~113 µs |
+
+**Low contention (2 producers):**
+
+| Mechanism | p50 | p99 | p99.9 |
+|---|---:|---:|---:|
+| `BQueue` | 250 | 333 | 4.3 µs |
+| `LockFreeMPSC` | 170 | 292 | **417 ns** |
+
+The far tail (p99.99+) is the OS scheduler, not the queue. To go under it: `SCHED_FIFO`,
+pin threads to dedicated cores, `isolcpus`.
+
+## How to select one
+
+Each actor picks its mailbox by which base constructor it calls. The default
+constructor gives you a `BQueue`; a protected `Actor(Queue<const Message*>*)`
+constructor lets a subclass install any mailbox (the `Actor` takes ownership and
+frees it in its destructor).
+
+```cpp
+// Default: single-lane BQueue — do nothing special.
+class Logger : public Actor {
+public:
+  Logger() { strncpy(name, "Logger", sizeof(name)); /* MESSAGE_HANDLER(...); */ }
+};
+
+// High fan-in actor: 8-lane sharded mailbox.
+#include "actors/ShardedBQueue.hpp"
+class OrderManager : public Actor {
+public:
+  OrderManager()
+    : Actor(new ShardedBQueue<const Message*>(8)) {
+    strncpy(name, "OrderManager", sizeof(name));
+    // MESSAGE_HANDLER(...);
+  }
+};
+
+// Few-producer, latency-critical actor: lock-free mailbox (capacity rounds up to pow2).
+#include "actors/LockFreeMPSC.hpp"
+class FastStrategy : public Actor {
+public:
+  FastStrategy()
+    : Actor(new LockFreeMPSC<const Message*>(4096)) {
+    strncpy(name, "FastStrategy", sizeof(name));
+    // MESSAGE_HANDLER(...);
+  }
+};
+```
+
+Constructor arguments: `BQueue(ring_size)`, `ShardedBQueue(num_lanes)`,
+`LockFreeMPSC(capacity)` (rounded up to a power of two). Everything downstream
+(`send`, `pop_batch`, the run loop) goes through the `Queue<T>` interface, so nothing
+else in the actor changes.
+
+> Note: mailbox selection is currently a C++ feature. The Rust port hard-codes
+> `BQueue`; matching it would mean making `ActorCell`'s queue a trait object.
+
+## Further reading
+
+The design and measurements behind these mailboxes:
+
+- [How Message Batching More Than Doubles Actor Model Throughput](https://vincentmayeski.substack.com/p/how-message-batching-more-than-doubles)
+- [Medians Lie, Tails Kill: Why Kaspar Shards Mailbox Locks](https://vincentmayeski.substack.com/p/medians-lie-tails-kill-why-kaspar)
+- [The Lock-Free Illusion: Why CAS Storms Kill Actor Queues Under Contention](https://vincentmayeski.substack.com/p/the-lock-free-illusion-why-cas-storms)

--- a/actors/cpp/MAILBOXES.md
+++ b/actors/cpp/MAILBOXES.md
@@ -98,6 +98,30 @@ Constructor arguments: `BQueue(ring_size)`, `ShardedBQueue(num_lanes)`,
 (`send`, `pop_batch`, the run loop) goes through the `Queue<T>` interface, so nothing
 else in the actor changes.
 
+### Why a runtime `Queue*`, not a template parameter?
+
+The mailbox is chosen at runtime through the virtual `Queue<T>` interface, not as
+a compile-time template (`Actor<Mailbox>`). That is deliberate:
+
+- **The mailbox is only touched on the async path.** `fast_send` — the latency-
+  critical fast path — bypasses the queue entirely and runs the handler inline
+  (`call_handler`), never calling `msgq`. `msgq->push` / `msgq->pop_batch` happen
+  only in `send()` and the run loop, which already cost **~125 ns (grouped) to
+  ~2250 ns (cross-thread)**. A virtual call there is ~2–5 ns — noise. Devirtualizing
+  it optimizes a cost that does not register.
+- **`Actor` is used polymorphically everywhere.** `Manager` and `Group` hold
+  `Actor*`, and `send()` takes `Actor*`. Making the mailbox a template parameter
+  would force a non-template `ActorBase` (the polymorphic surface) with
+  `Actor<Mailbox>` derived from it, and one full `Actor` instantiation per mailbox
+  type — real complexity and code bloat for an unmeasurable win.
+
+So a runtime `Queue*` gives per-actor selection, a single `Actor` type, and a
+`pop_batch` default impl, with the virtual dispatch riding a path where it is free.
+If a benchmark ever showed the `Queue` virtual call actually costing something, the
+clean compile-time form would be a policy template with a non-template base
+(`template <class Mailbox> class Actor : public ActorBase { Mailbox msgq; }`) — but
+since it rides a ≥125 ns path, it won't.
+
 > Note: mailbox selection is currently a C++ feature. The Rust port hard-codes
 > `BQueue`; matching it would mean making `ActorCell`'s queue a trait object.
 

--- a/actors/cpp/examples/jitter_contention.cpp
+++ b/actors/cpp/examples/jitter_contention.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 Vincent Mayeski / M2 Tech (16425640 Canada Inc.).
+ * Licensed under the MIT License. See LICENSE file in the project root.
+ *
+ * Push-latency jitter of the real mailbox data structures under P producers.
+ *
+ *   bq  : BQueue        (one mutex)
+ *   sbq : ShardedBQueue (N mutex lanes, round-robin)
+ *   lf  : LockFreeMPSC  (Vyukov bounded ring, park-free push)
+ *
+ * Usage: ./jitter_contention <bq|sbq|lf> [num_producers]
+ */
+
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+#include <thread>
+#include <chrono>
+#include <algorithm>
+#include <cstdint>
+#include "actors/BQueue.hpp"
+#include "actors/ShardedBQueue.hpp"
+#include "actors/LockFreeMPSC.hpp"
+
+using actors::BQueue;
+using actors::ShardedBQueue;
+using actors::LockFreeMPSC;
+using actors::Queue;
+using clk = std::chrono::steady_clock;
+
+static const uint64_t K = 1'000'000; // pushes per producer
+
+static void producer(Queue<const void*>* q, std::vector<uint32_t>* lat) {
+    lat->resize(K);
+    for (uint64_t i = 0; i < K; i++) {
+        auto t0 = clk::now();
+        q->push(reinterpret_cast<const void*>(i + 1));
+        auto t1 = clk::now();
+        (*lat)[i] = (uint32_t)std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
+    }
+}
+
+int main(int argc, char** argv) {
+    std::string mode = argc > 1 ? argv[1] : "bq";
+    int P = argc > 2 ? std::atoi(argv[2]) : 8;
+
+    Queue<const void*>* q;
+    const char* name;
+    if (mode == "sbq")      { q = new ShardedBQueue<const void*>(8);        name = "ShardedBQueue"; }
+    else if (mode == "lf")  { q = new LockFreeMPSC<const void*>((size_t)P * K); name = "LockFreeMPSC"; }
+    else                    { q = new BQueue<const void*>((size_t)P * K);   name = "BQueue"; }
+
+    printf("=== %-14s : %d producers x %llu pushes ===\n", name, P, (unsigned long long)K);
+
+    std::vector<std::vector<uint32_t>> lat(P);
+    std::vector<std::thread> th;
+    for (int p = 0; p < P; p++) th.emplace_back(producer, q, &lat[p]);
+    for (auto& t : th) t.join();
+
+    std::vector<uint32_t> all;
+    for (auto& v : lat) all.insert(all.end(), v.begin(), v.end());
+    std::sort(all.begin(), all.end());
+    auto pct = [&](double p) { return all[(size_t)(p * (all.size() - 1))]; };
+    double sum = 0; for (auto v : all) sum += v;
+    printf("%-4s  mean %5.0f  p50 %5u  p99 %7u  p99.9 %8u  p99.99 %9u  (ns/push)\n",
+           mode.c_str(), sum / all.size(), pct(0.50), pct(0.99), pct(0.999), pct(0.9999));
+    return 0;
+}

--- a/actors/cpp/examples/ping_pong_batch.cpp
+++ b/actors/cpp/examples/ping_pong_batch.cpp
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2026 Vincent Mayeski / M2 Tech (16425640 Canada Inc.).
+ * Contact: v@m2te.ch | https://www.linkedin.com/in/vmayeski/
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root.
+ */
+
+/**
+ * Batched async ping-pong benchmark, with optional producer-side batching and a
+ * message pool (compile-time flags), to measure what beats the 1.6x that
+ * consumer-side batching (Lever 1+2) alone gives.
+ *
+ *   -DUSE_SEND_BATCH : fire a burst with one send_batch() (one lock) vs N send()
+ *   -DUSE_POOL       : recycle Ping/Pong through a free-list vs new/delete
+ */
+
+#include <iostream>
+#include <chrono>
+#include <cstring>
+#include <mutex>
+#include <vector>
+#include <condition_variable>
+#include "actors/Actor.hpp"
+#include "actors/act/Manager.hpp"
+#include "actors/msg/Start.hpp"
+#ifdef USE_POOL
+#include "actors/MemoryPool.hpp"   // framework's thread-local-cache + slab pool
+#endif
+
+using namespace actors;
+using namespace std;
+
+static const int BATCH = 10000;  // messages per burst
+static const int ROUNDS = 1000;  // number of bursts => BATCH*ROUNDS round-trips
+
+static std::mutex g_mtx;
+static std::condition_variable g_cv;
+static bool g_done = false;
+
+// Use the framework's MemoryPool (inherited => pooled operator new/delete).
+// Message has a virtual dtor, so `delete (Message*)p` dispatches to the derived
+// pool's sized operator delete.
+#ifdef USE_POOL
+struct Ping : public Message_N<100>, public MemoryPool<Ping> { int count; Ping(int c) : count(c) {} };
+struct Pong : public Message_N<101>, public MemoryPool<Pong> { int count; Pong(int c) : count(c) {} };
+#else
+struct Ping : public Message_N<100> { int count; Ping(int c) : count(c) {} };
+struct Pong : public Message_N<101> { int count; Pong(int c) : count(c) {} };
+#endif
+
+class PingActor : public Actor {
+  Actor* pong_actor;
+  Actor* manager;
+  long recv = 0;
+  int  bursts_sent = 0;
+public:
+  PingActor(Actor* pong, Actor* mgr) : pong_actor(pong), manager(mgr) {
+    strncpy(name, "PingActor", sizeof(name));
+    MESSAGE_HANDLER(msg::Start, on_start);
+    MESSAGE_HANDLER(Pong, on_pong);
+  }
+  void fire() {
+    for (int i = 0; i < BATCH; i++) pong_actor->send(new Ping(1), this);
+    bursts_sent++;
+  }
+  void on_start(const msg::Start*) { fire(); }
+  void on_pong(const Pong*) {
+    recv++;
+    if (recv >= (long)BATCH * ROUNDS) {
+      { std::lock_guard<std::mutex> lk(g_mtx); g_done = true; }
+      g_cv.notify_one();
+      return;
+    }
+    if (recv % BATCH == 0 && bursts_sent < ROUNDS) fire();
+  }
+};
+
+class PongActor : public Actor {
+public:
+  PongActor() {
+    strncpy(name, "PongActor", sizeof(name));
+    MESSAGE_HANDLER(Ping, on_ping);
+  }
+  void on_ping(const Ping* m) { reply(new Pong(m->count)); }
+};
+
+int main() {
+  const long total = (long)BATCH * ROUNDS;
+  cout << "=== C++ batched ping-pong"
+#ifdef USE_SEND_BATCH
+       << " +send_batch"
+#endif
+#ifdef USE_POOL
+       << " +pool"
+#endif
+       << ": burst=" << BATCH << " round-trips=" << total << " ===" << endl;
+
+  Manager mgr;
+  auto* pong = new PongActor();
+  auto* ping = new PingActor(pong, &mgr);
+  mgr.add_to_manage_q(pong);
+  mgr.add_to_manage_q(ping);
+
+  auto t0 = chrono::steady_clock::now();
+  mgr.init();
+  { std::unique_lock<std::mutex> lk(g_mtx); g_cv.wait(lk, [] { return g_done; }); }
+  double dt = chrono::duration<double>(chrono::steady_clock::now() - t0).count();
+  mgr.end();
+
+  cout << total << " round-trips in " << dt << "s  ("
+       << total / dt / 1e6 << " M rt/s, " << 2.0 * total / dt / 1e6 << " M msgs/s, "
+       << dt / total * 1e9 << " ns/rt)" << endl;
+  return 0;
+}

--- a/actors/cpp/examples/ping_pong_depth1.cpp
+++ b/actors/cpp/examples/ping_pong_depth1.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026 Vincent Mayeski / M2 Tech (16425640 Canada Inc.).
+ * Contact: v@m2te.ch | https://www.linkedin.com/in/vmayeski/
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root.
+ */
+
+/**
+ * Depth-1 async ping-pong: exactly one message in flight. The consumer's mailbox
+ * is empty between messages, so each round-trip pays two condvar wakeups. This is
+ * the microsecond, wakeup-bound regime (contrast ping_pong_batch.cpp). Batching
+ * cannot help here — there is never more than one message to batch.
+ */
+
+#include <iostream>
+#include <chrono>
+#include <cstring>
+#include <mutex>
+#include <condition_variable>
+#include "actors/Actor.hpp"
+#include "actors/act/Manager.hpp"
+#include "actors/msg/Start.hpp"
+
+using namespace actors;
+using namespace std;
+
+static const long MAX = 1'000'000; // round-trips
+
+static std::mutex g_mtx;
+static std::condition_variable g_cv;
+static bool g_done = false;
+
+struct Ping : public Message_N<100> { int count; Ping(int c) : count(c) {} };
+struct Pong : public Message_N<101> { int count; Pong(int c) : count(c) {} };
+
+class PingActor : public Actor {
+  Actor* pong_actor;
+  long   recv = 0;
+public:
+  PingActor(Actor* pong) : pong_actor(pong) {
+    strncpy(name, "PingActor", sizeof(name));
+    MESSAGE_HANDLER(msg::Start, on_start);
+    MESSAGE_HANDLER(Pong, on_pong);
+  }
+  void on_start(const msg::Start*) { pong_actor->send(new Ping(1), this); }
+  void on_pong(const Pong*) {
+    recv++;
+    if (recv >= MAX) {
+      { std::lock_guard<std::mutex> lk(g_mtx); g_done = true; }
+      g_cv.notify_one();
+      return;
+    }
+    pong_actor->send(new Ping(1), this);  // one in flight
+  }
+};
+
+class PongActor : public Actor {
+public:
+  PongActor() {
+    strncpy(name, "PongActor", sizeof(name));
+    MESSAGE_HANDLER(Ping, on_ping);
+  }
+  void on_ping(const Ping* m) { reply(new Pong(m->count)); }
+};
+
+int main() {
+  cout << "=== C++ depth-1 ping-pong: round-trips=" << MAX << " ===" << endl;
+  Manager mgr;
+  auto* pong = new PongActor();
+  auto* ping = new PingActor(pong);
+  mgr.add_to_manage_q(pong);
+  mgr.add_to_manage_q(ping);
+
+  auto t0 = chrono::steady_clock::now();
+  mgr.init();
+  { std::unique_lock<std::mutex> lk(g_mtx); g_cv.wait(lk, [] { return g_done; }); }
+  double dt = chrono::duration<double>(chrono::steady_clock::now() - t0).count();
+  mgr.end();
+
+  cout << MAX << " round-trips in " << dt << "s  ("
+       << MAX / dt / 1e6 << " M rt/s, " << dt / MAX * 1e6 << " us/round-trip)" << endl;
+  return 0;
+}

--- a/actors/cpp/include/actors/Actor.hpp
+++ b/actors/cpp/include/actors/Actor.hpp
@@ -83,6 +83,15 @@ namespace actors
     Actor(const Actor&) = delete;
     Actor& operator=(const Actor&) = delete;
 
+  protected:
+    // Construct with a specific mailbox implementation (takes ownership). Lets a
+    // subclass opt into a different Queue<T> — e.g. ShardedBQueue for an actor
+    // with many producers, to cut lock-contention jitter. Default ctor uses a
+    // single-lane BQueue.
+    explicit Actor(Queue<const Message *> *mailbox);
+
+  public:
+
     /**
      * Send a message asynchronously (fire-and-forget)
      * Message is queued and processed later by receiver's thread

--- a/actors/cpp/include/actors/BQueue.hpp
+++ b/actors/cpp/include/actors/BQueue.hpp
@@ -66,17 +66,36 @@ namespace actors
       return !cb_.empty() ? cb_.front() : overflow_.front();
     }
 
+    // Single-lock batch drain: block until >=1 item, then move the whole queue
+    // (ring then overflow, FIFO) into `out`. N queued items => one lock, not N.
+    void pop_batch(std::vector<T>& out) override
+    {
+      out.clear();
+      std::unique_lock<std::mutex> lock(mut);
+      cv.wait(lock, [this]() {
+        return !cb_.empty() || !overflow_.empty();
+      });
+      out.reserve(cb_.size() + overflow_.size());
+      while (!cb_.empty())       { out.push_back(cb_.front());       cb_.pop_front(); }
+      while (!overflow_.empty()) { out.push_back(overflow_.front()); overflow_.pop_front(); }
+    }
+
     void push(const T& x) noexcept override
     {
+      bool was_empty;
       {
         std::lock_guard<std::mutex> lock(mut);
+        was_empty = cb_.empty() && overflow_.empty();
         if (!overflow_.empty() || cb_.full()) {
           overflow_.push_back(x);
         } else {
           cb_.push_back(x);
         }
       }
-      cv.notify_one();
+      // The consumer only cv.wait()s when it finds the queue empty under the
+      // lock, so only the push that makes it non-empty must signal. Skips a
+      // notify syscall on every push into a backlog.
+      if (was_empty) cv.notify_one();
     }
 
     bool is_empty() const noexcept override

--- a/actors/cpp/include/actors/LockFreeMPSC.hpp
+++ b/actors/cpp/include/actors/LockFreeMPSC.hpp
@@ -49,6 +49,19 @@ namespace actors
       size_t p = 1; while (p < n) p <<= 1; return p;
     }
 
+    static inline void cpu_relax() noexcept {
+#if defined(__x86_64__) || defined(__i386__)
+      __builtin_ia32_pause();
+#elif defined(__aarch64__) || defined(__arm__)
+      __asm__ __volatile__("yield");
+#endif
+    }
+
+    // Cap on items drained per pop_batch call — guarantees the call RETURNS even
+    // under sustained overload (producers outrunning the consumer), instead of
+    // looping forever while `out` grows unbounded. Leftovers go to the next call.
+    static constexpr size_t kMaxDrain = 8192;
+
     std::vector<Cell>          buf_;
     const size_t               mask_;
     alignas(64) std::atomic<size_t> enqueue_pos_{0};
@@ -112,8 +125,13 @@ namespace actors
 
     // --- Queue<T> interface ---
     void push(const T& x) noexcept override {
-      while (!try_push(x)) { /* ring full: spin until the consumer drains */ }
-      if (parked_.load(std::memory_order_acquire)) {
+      while (!try_push(x)) cpu_relax();   // ring full: spin (pause) until consumer drains
+      // Matching seq_cst fence for the transition-notify handshake (see the
+      // consumer's fence below). Without a fence on BOTH sides the producer can
+      // read parked_==false stale and skip the wakeup while the consumer parks on
+      // a non-empty queue — a lost wakeup only masked by wait_for()'s timeout.
+      std::atomic_thread_fence(std::memory_order_seq_cst);
+      if (parked_.load(std::memory_order_relaxed)) {
         { std::lock_guard<std::mutex> lk(wait_mtx_); }
         cv_.notify_one();
       }
@@ -123,15 +141,16 @@ namespace actors
       out.clear();
       for (;;) {
         T v;
-        while (try_pop(v)) out.push_back(v);
+        while (out.size() < kMaxDrain && try_pop(v)) out.push_back(v);
         if (!out.empty()) return;
         // empty: park with a bounded safety-net wait
         std::unique_lock<std::mutex> lk(wait_mtx_);
-        parked_.store(true, std::memory_order_release);
+        parked_.store(true, std::memory_order_relaxed);
+        std::atomic_thread_fence(std::memory_order_seq_cst);   // pairs w/ producer
         if (try_pop(v)) {                                   // re-check after arming
           parked_.store(false, std::memory_order_relaxed);
           out.push_back(v);
-          while (try_pop(v)) out.push_back(v);
+          while (out.size() < kMaxDrain && try_pop(v)) out.push_back(v);
           return;
         }
         cv_.wait_for(lk, std::chrono::milliseconds(1));
@@ -144,7 +163,8 @@ namespace actors
         T v;
         if (try_pop(v)) return std::make_tuple(v, is_empty());
         std::unique_lock<std::mutex> lk(wait_mtx_);
-        parked_.store(true, std::memory_order_release);
+        parked_.store(true, std::memory_order_relaxed);
+        std::atomic_thread_fence(std::memory_order_seq_cst);   // pairs w/ producer
         if (try_pop(v)) { parked_.store(false, std::memory_order_relaxed); return std::make_tuple(v, is_empty()); }
         cv_.wait_for(lk, std::chrono::milliseconds(1));
         parked_.store(false, std::memory_order_relaxed);

--- a/actors/cpp/include/actors/LockFreeMPSC.hpp
+++ b/actors/cpp/include/actors/LockFreeMPSC.hpp
@@ -1,0 +1,173 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026 Vincent Mayeski / M2 Tech (16425640 Canada Inc.).
+ * Contact: v@m2te.ch | https://www.linkedin.com/in/vmayeski/
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root.
+ */
+
+#include <atomic>
+#include <vector>
+#include <mutex>
+#include <condition_variable>
+#include <chrono>
+#include <tuple>
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+#include "actors/Queue.hpp"
+
+namespace actors
+{
+  /**
+   * LockFreeMPSC - a bounded, lock-free multi-producer / single-consumer mailbox
+   * (Dmitry Vyukov's bounded MPMC ring, used here as MPSC).
+   *
+   * Push is PARK-FREE: a producer claims a slot with a CAS on enqueue_pos and
+   * publishes it via a per-cell sequence number. Producers never hold a lock and
+   * never sleep, so contention costs bounded cache-coherence latency (hundreds of
+   * ns) instead of a microsecond futex park. That is the point: a flat tail.
+   *
+   * Consumer blocking (pop/pop_batch) uses a condvar + `parked` flag with
+   * transition-notify, so producers touch the shared wakeup path ONLY when the
+   * consumer is actually asleep (never, under load). A bounded wait_for() is a
+   * safety net against a missed wakeup.
+   *
+   * Bounded: if the ring is full, push() spins until the consumer frees a slot.
+   * Size the ring for peak backlog.
+   */
+  template <class T>
+  class LockFreeMPSC : public Queue<T>
+  {
+    struct Cell {
+      std::atomic<size_t> seq;
+      T                   data;
+    };
+
+    static size_t round_up_pow2(size_t n) {
+      size_t p = 1; while (p < n) p <<= 1; return p;
+    }
+
+    std::vector<Cell>          buf_;
+    const size_t               mask_;
+    alignas(64) std::atomic<size_t> enqueue_pos_{0};
+    alignas(64) std::atomic<size_t> dequeue_pos_{0};
+
+    // consumer wakeup
+    alignas(64) std::mutex          wait_mtx_;
+    std::condition_variable         cv_;
+    std::atomic<bool>               parked_{false};
+
+  public:
+    explicit LockFreeMPSC(size_t capacity = 1024)
+      : buf_(round_up_pow2(capacity)), mask_(buf_.size() - 1)
+    {
+      for (size_t i = 0; i < buf_.size(); i++)
+        buf_[i].seq.store(i, std::memory_order_relaxed);
+    }
+
+    // --- lock-free primitives ---
+    bool try_push(const T& x) noexcept {
+      Cell* cell;
+      size_t pos = enqueue_pos_.load(std::memory_order_relaxed);
+      for (;;) {
+        cell = &buf_[pos & mask_];
+        size_t seq = cell->seq.load(std::memory_order_acquire);
+        intptr_t dif = (intptr_t)seq - (intptr_t)pos;
+        if (dif == 0) {
+          if (enqueue_pos_.compare_exchange_weak(pos, pos + 1, std::memory_order_relaxed))
+            break;
+        } else if (dif < 0) {
+          return false;  // full
+        } else {
+          pos = enqueue_pos_.load(std::memory_order_relaxed);
+        }
+      }
+      cell->data = x;
+      cell->seq.store(pos + 1, std::memory_order_release);
+      return true;
+    }
+
+    bool try_pop(T& out) noexcept {
+      Cell* cell;
+      size_t pos = dequeue_pos_.load(std::memory_order_relaxed);
+      for (;;) {
+        cell = &buf_[pos & mask_];
+        size_t seq = cell->seq.load(std::memory_order_acquire);
+        intptr_t dif = (intptr_t)seq - (intptr_t)(pos + 1);
+        if (dif == 0) {
+          if (dequeue_pos_.compare_exchange_weak(pos, pos + 1, std::memory_order_relaxed))
+            break;
+        } else if (dif < 0) {
+          return false;  // empty
+        } else {
+          pos = dequeue_pos_.load(std::memory_order_relaxed);
+        }
+      }
+      out = cell->data;
+      cell->seq.store(pos + mask_ + 1, std::memory_order_release);
+      return true;
+    }
+
+    // --- Queue<T> interface ---
+    void push(const T& x) noexcept override {
+      while (!try_push(x)) { /* ring full: spin until the consumer drains */ }
+      if (parked_.load(std::memory_order_acquire)) {
+        { std::lock_guard<std::mutex> lk(wait_mtx_); }
+        cv_.notify_one();
+      }
+    }
+
+    void pop_batch(std::vector<T>& out) override {
+      out.clear();
+      for (;;) {
+        T v;
+        while (try_pop(v)) out.push_back(v);
+        if (!out.empty()) return;
+        // empty: park with a bounded safety-net wait
+        std::unique_lock<std::mutex> lk(wait_mtx_);
+        parked_.store(true, std::memory_order_release);
+        if (try_pop(v)) {                                   // re-check after arming
+          parked_.store(false, std::memory_order_relaxed);
+          out.push_back(v);
+          while (try_pop(v)) out.push_back(v);
+          return;
+        }
+        cv_.wait_for(lk, std::chrono::milliseconds(1));
+        parked_.store(false, std::memory_order_relaxed);
+      }
+    }
+
+    std::tuple<T, bool> pop() noexcept override {
+      for (;;) {
+        T v;
+        if (try_pop(v)) return std::make_tuple(v, is_empty());
+        std::unique_lock<std::mutex> lk(wait_mtx_);
+        parked_.store(true, std::memory_order_release);
+        if (try_pop(v)) { parked_.store(false, std::memory_order_relaxed); return std::make_tuple(v, is_empty()); }
+        cv_.wait_for(lk, std::chrono::milliseconds(1));
+        parked_.store(false, std::memory_order_relaxed);
+      }
+    }
+
+    T peek() const noexcept override {
+      size_t pos = dequeue_pos_.load(std::memory_order_relaxed);
+      Cell& cell = const_cast<Cell&>(buf_[pos & mask_]);
+      size_t seq = cell.seq.load(std::memory_order_acquire);
+      if ((intptr_t)seq - (intptr_t)(pos + 1) == 0) return cell.data;
+      if constexpr (std::is_pointer<T>::value) return nullptr; else return T{};
+    }
+
+    bool is_empty() const noexcept override {
+      return dequeue_pos_.load(std::memory_order_relaxed) ==
+             enqueue_pos_.load(std::memory_order_relaxed);
+    }
+
+    std::size_t length() const noexcept override {
+      size_t e = enqueue_pos_.load(std::memory_order_relaxed);
+      size_t d = dequeue_pos_.load(std::memory_order_relaxed);
+      return e > d ? e - d : 0;
+    }
+  };
+}

--- a/actors/cpp/include/actors/Queue.hpp
+++ b/actors/cpp/include/actors/Queue.hpp
@@ -9,6 +9,7 @@
 
 #include <tuple>
 #include <cstddef>
+#include <vector>
 
 namespace actors
 {
@@ -29,5 +30,18 @@ namespace actors
     virtual void push(const T& x) = 0;
     virtual bool is_empty() const = 0;
     virtual std::size_t length() const = 0;
+
+    // Batch-blocking drain: block until >=1 item, then move all currently-queued
+    // items into `out` (FIFO). Default loops pop() (correct but still one lock
+    // per item); BQueue overrides it with a single-lock drain.
+    virtual void pop_batch(std::vector<T>& out)
+    {
+      out.clear();
+      for (;;) {
+        auto r = pop();
+        out.push_back(std::get<0>(r));
+        if (std::get<1>(r)) return; // `last` == queue now empty
+      }
+    }
   };
 }

--- a/actors/cpp/include/actors/ShardedBQueue.hpp
+++ b/actors/cpp/include/actors/ShardedBQueue.hpp
@@ -84,22 +84,32 @@ namespace actors
         std::lock_guard<std::mutex> lk(lanes_[lane].mtx);
         lanes_[lane].dq.push_back(x);
       }
-      // transition-notify: only pay the shared path if the consumer is parked.
-      // No full fence on the hot path — the consumer's bounded wait_for() is the
-      // safety net, so a rarely-missed wakeup is healed within the timeout, never
-      // lost. Under load the consumer never parks, so this is a cheap acquire load.
-      if (parked_.load(std::memory_order_acquire)) {
+      // transition-notify. The consumer arms `parked_` (relaxed) + a seq_cst fence
+      // + re-check; the producer needs the MATCHING seq_cst fence between the push
+      // above and the parked_ load below. A one-sided fence does not order the two
+      // threads, so without this fence a producer could read parked_==false stale
+      // and skip the wakeup while the consumer parks on a non-empty queue — a lost
+      // wakeup only papered over by wait_for()'s timeout (a 1ms tail stall). The
+      // two fences establish the total order that makes the handshake correct.
+      std::atomic_thread_fence(std::memory_order_seq_cst);   // StoreLoad, pairs w/ consumer
+      if (parked_.load(std::memory_order_relaxed)) {
         { std::lock_guard<std::mutex> lk(wait_mtx_); }       // serialize vs consumer entering wait()
         cv_.notify_one();
       }
     }
 
-    // Drain everything currently queued into `out`, in round-robin order.
-    // Blocks until at least one item is available.
+    // Drain up to kMaxDrain items currently queued into `out`, round-robin order.
+    // Blocks until at least one item is available. The cap guarantees the call
+    // RETURNS even under sustained overload (producers outrunning the consumer):
+    // without it the rotation loop never sees an all-empty pass and pop_batch
+    // would never return while `out` grew without bound. Leftovers are picked up
+    // by the next call.
+    static constexpr size_t kMaxDrain = 8192;
     void pop_batch(std::vector<T>& out) override {
       out.clear();
       for (;;) {
         // drain: rotate over lanes popping one each, until a full pass is empty
+        // or we hit the per-call cap.
         for (;;) {
           bool progressed = false;
           for (size_t j = 0; j < n_; j++) {
@@ -107,7 +117,7 @@ namespace actors
             std::lock_guard<std::mutex> lk(L.mtx);
             if (!L.dq.empty()) { out.push_back(L.dq.front()); L.dq.pop_front(); progressed = true; }
           }
-          if (!progressed) break;
+          if (!progressed || out.size() >= kMaxDrain) break;
         }
         if (!out.empty()) return;
 

--- a/actors/cpp/include/actors/ShardedBQueue.hpp
+++ b/actors/cpp/include/actors/ShardedBQueue.hpp
@@ -1,0 +1,176 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026 Vincent Mayeski / M2 Tech (16425640 Canada Inc.).
+ * Contact: v@m2te.ch | https://www.linkedin.com/in/vmayeski/
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root.
+ */
+
+#include <mutex>
+#include <condition_variable>
+#include <deque>
+#include <vector>
+#include <atomic>
+#include <chrono>
+#include <tuple>
+#include <type_traits>
+#include <cstddef>
+#include <cstdint>
+#include "actors/Queue.hpp"
+
+namespace actors
+{
+  /**
+   * ShardedBQueue - a mailbox split into N independent lanes to reduce
+   * producer-side lock contention (and therefore tail-latency jitter) when many
+   * threads send to one actor.
+   *
+   *   push : round-robin across lanes (a shared atomic cursor picks the lane), so
+   *          P producers spread over N locks instead of hammering one.
+   *   pull : the single consumer drains round-robin (one item per lane per
+   *          rotation), reconstructing round-robin arrival order.
+   *
+   * Trade-offs vs BQueue (choose per actor):
+   *  - Reduces push contention ~N x -> lower jitter with many producers.
+   *  - Does NOT preserve per-sender FIFO (round-robin spreads a sender across
+   *    lanes). Use BQueue where per-sender order or whole-mailbox batch drain
+   *    matters and contention is low.
+   *
+   * Consumer wakeup: a single condvar + `parked` flag with transition-notify, so
+   * producers touch the shared wakeup path ONLY when the consumer is actually
+   * asleep (i.e. never, under load). A bounded wait (`wait_for`) is a safety net:
+   * even if a wakeup were ever missed, the consumer re-checks within the timeout
+   * rather than hanging.
+   */
+  template <class T>
+  class ShardedBQueue : public Queue<T>
+  {
+    struct alignas(64) Lane {
+      std::mutex     mtx;
+      std::deque<T>  dq;
+    };
+
+    std::vector<Lane>          lanes_;
+    const size_t               n_;
+    std::atomic<uint64_t>      push_cursor_{0};
+    size_t                     pull_cursor_ = 0;  // consumer-only
+
+    // shared consumer wakeup
+    std::mutex                 wait_mtx_;
+    std::condition_variable    cv_;
+    std::atomic<bool>          parked_{false};
+
+    bool any_nonempty() {
+      for (size_t i = 0; i < n_; i++) {
+        std::lock_guard<std::mutex> lk(lanes_[i].mtx);
+        if (!lanes_[i].dq.empty()) return true;
+      }
+      return false;
+    }
+
+  public:
+    explicit ShardedBQueue(size_t lanes = 8)
+      : lanes_(lanes ? lanes : 1), n_(lanes ? lanes : 1) {}
+
+    void push(const T& x) noexcept override {
+      // Shared round-robin cursor: the atomic fetch_add serializes producers just
+      // enough to guarantee consecutive pushes land on DIFFERENT lanes, which
+      // minimizes lane-lock collisions and keeps the TAIL short (the whole point
+      // of a sharded mailbox). It costs some median (contended atomic line) but
+      // that cost is bounded, so the distribution stays flat.
+      size_t lane = (size_t)(push_cursor_.fetch_add(1, std::memory_order_relaxed) % n_);
+      {
+        std::lock_guard<std::mutex> lk(lanes_[lane].mtx);
+        lanes_[lane].dq.push_back(x);
+      }
+      // transition-notify: only pay the shared path if the consumer is parked.
+      // No full fence on the hot path — the consumer's bounded wait_for() is the
+      // safety net, so a rarely-missed wakeup is healed within the timeout, never
+      // lost. Under load the consumer never parks, so this is a cheap acquire load.
+      if (parked_.load(std::memory_order_acquire)) {
+        { std::lock_guard<std::mutex> lk(wait_mtx_); }       // serialize vs consumer entering wait()
+        cv_.notify_one();
+      }
+    }
+
+    // Drain everything currently queued into `out`, in round-robin order.
+    // Blocks until at least one item is available.
+    void pop_batch(std::vector<T>& out) override {
+      out.clear();
+      for (;;) {
+        // drain: rotate over lanes popping one each, until a full pass is empty
+        for (;;) {
+          bool progressed = false;
+          for (size_t j = 0; j < n_; j++) {
+            Lane& L = lanes_[(pull_cursor_ + j) % n_];
+            std::lock_guard<std::mutex> lk(L.mtx);
+            if (!L.dq.empty()) { out.push_back(L.dq.front()); L.dq.pop_front(); progressed = true; }
+          }
+          if (!progressed) break;
+        }
+        if (!out.empty()) return;
+
+        // all lanes empty: park until a producer signals (bounded as a safety net)
+        std::unique_lock<std::mutex> lk(wait_mtx_);
+        parked_.store(true, std::memory_order_relaxed);
+        std::atomic_thread_fence(std::memory_order_seq_cst);  // StoreLoad
+        if (any_nonempty()) { parked_.store(false, std::memory_order_relaxed); continue; }
+        cv_.wait_for(lk, std::chrono::milliseconds(1));
+        parked_.store(false, std::memory_order_relaxed);
+      }
+    }
+
+    // Single-item pop (round-robin). `last` == queue now empty. Blocks until an
+    // item is available.
+    std::tuple<T, bool> pop() noexcept override {
+      for (;;) {
+        for (size_t j = 0; j < n_; j++) {
+          Lane& L = lanes_[(pull_cursor_ + j) % n_];
+          std::unique_lock<std::mutex> lk(L.mtx);
+          if (!L.dq.empty()) {
+            T v = L.dq.front();
+            L.dq.pop_front();
+            pull_cursor_ = (pull_cursor_ + j + 1) % n_;  // advance past the lane we took from
+            lk.unlock();
+            return std::make_tuple(v, !any_nonempty());
+          }
+        }
+        std::unique_lock<std::mutex> lk(wait_mtx_);
+        parked_.store(true, std::memory_order_relaxed);
+        std::atomic_thread_fence(std::memory_order_seq_cst);
+        if (any_nonempty()) { parked_.store(false, std::memory_order_relaxed); continue; }
+        cv_.wait_for(lk, std::chrono::milliseconds(1));
+        parked_.store(false, std::memory_order_relaxed);
+      }
+    }
+
+    T peek() const noexcept override {
+      for (size_t j = 0; j < n_; j++) {
+        auto& L = const_cast<Lane&>(lanes_[(pull_cursor_ + j) % n_]);
+        std::lock_guard<std::mutex> lk(L.mtx);
+        if (!L.dq.empty()) return L.dq.front();
+      }
+      if constexpr (std::is_pointer<T>::value) return nullptr; else return T{};
+    }
+
+    bool is_empty() const noexcept override {
+      for (size_t i = 0; i < n_; i++) {
+        auto& L = const_cast<Lane&>(lanes_[i]);
+        std::lock_guard<std::mutex> lk(L.mtx);
+        if (!L.dq.empty()) return false;
+      }
+      return true;
+    }
+
+    std::size_t length() const noexcept override {
+      std::size_t total = 0;
+      for (size_t i = 0; i < n_; i++) {
+        auto& L = const_cast<Lane&>(lanes_[i]);
+        std::lock_guard<std::mutex> lk(L.mtx);
+        total += L.dq.size();
+      }
+      return total;
+    }
+  };
+}

--- a/actors/cpp/tests/test_actor_batch.cpp
+++ b/actors/cpp/tests/test_actor_batch.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 Vincent Mayeski / M2 Tech (16425640 Canada Inc.).
+ * Contact: v@m2te.ch | https://www.linkedin.com/in/vmayeski/
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root.
+ *
+ * Actor-level tests for the batch-drain run loop:
+ *  - DefaultMailboxIsBQueue: the default Actor mailbox is a plain BQueue (the
+ *    sharded / lock-free mailboxes are strictly opt-in). This is a guard test —
+ *    it fails if anyone changes the default mailbox type.
+ *  - MidBatchTerminateNoLeak: when a handler terminates the actor mid-batch, the
+ *    remaining co-drained messages are freed, not leaked.
+ */
+
+#include <gtest/gtest.h>
+#include <atomic>
+#include <cstring>
+#include "actors/Actor.hpp"
+#include "actors/BQueue.hpp"
+#include "actors/ShardedBQueue.hpp"
+
+using namespace actors;
+
+// --- guard: the default mailbox must stay a plain BQueue ---------------------
+
+class ProbeActor : public Actor {
+public:
+  ProbeActor() { strncpy(name, "Probe", sizeof(name)); }
+  Queue<const Message *> *mailbox() const { return msgq; }
+};
+
+TEST(ActorMailbox, DefaultIsBQueue) {
+  ProbeActor a;
+  auto *mb = a.mailbox();
+  EXPECT_NE(dynamic_cast<BQueue<const Message *> *>(mb), nullptr)
+      << "default Actor mailbox must be a BQueue";
+  EXPECT_EQ(dynamic_cast<ShardedBQueue<const Message *> *>(mb), nullptr)
+      << "default Actor mailbox must NOT be a ShardedBQueue";
+}
+
+// --- leak guard: mid-batch terminate frees the rest of the batch -------------
+
+struct CountedMsg : public Message_N<50> {
+  static std::atomic<int> alive;
+  CountedMsg() { alive.fetch_add(1); }
+  ~CountedMsg() override { alive.fetch_sub(1); }
+};
+std::atomic<int> CountedMsg::alive{0};
+
+// Terminates itself when it processes the FIRST message (like RegistryActor /
+// CoordinatorActor, which set terminated from a handler).
+class Terminator : public Actor {
+  int seen_ = 0;
+public:
+  Terminator() {
+    strncpy(name, "Terminator", sizeof(name));
+    MESSAGE_HANDLER(CountedMsg, on_msg);
+  }
+  void on_msg(const CountedMsg *) {
+    if (++seen_ == 1) terminated = true;   // terminate mid-batch
+  }
+};
+
+TEST(ActorBatch, MidBatchTerminateNoLeak) {
+  ASSERT_EQ(CountedMsg::alive.load(), 0);
+  {
+    Terminator a;
+    for (int i = 0; i < 5; ++i) a.send(new CountedMsg(), nullptr);  // 5 queued together
+    EXPECT_EQ(CountedMsg::alive.load(), 5);
+    a();  // run loop: drains all 5 in one batch, processes #1 (terminates), must
+          // delete the remaining 4 rather than leak them
+  }
+  EXPECT_EQ(CountedMsg::alive.load(), 0)
+      << "messages drained after a mid-batch terminate must be freed, not leaked";
+}

--- a/actors/cpp/tests/test_bqueue.cpp
+++ b/actors/cpp/tests/test_bqueue.cpp
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2026 Vincent Mayeski / M2 Tech (16425640 Canada Inc.).
+ * Contact: v@m2te.ch | https://www.linkedin.com/in/vmayeski/
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root.
+ *
+ * BQueue unit tests: FIFO/last-flag basics plus the batched-drain scenarios
+ * (pop_batch drains ring-then-overflow in FIFO, clears its out-param, blocks
+ * until pushed via transition-notify, and stays correct under a concurrent
+ * producer/consumer).
+ */
+
+#include <gtest/gtest.h>
+#include <vector>
+#include <thread>
+#include <chrono>
+#include <tuple>
+#include "actors/BQueue.hpp"
+
+using actors::BQueue;
+
+TEST(BQueue, FifoAndLastFlag) {
+  BQueue<int> q(2);
+  q.push(1);
+  q.push(2);
+  q.push(3);  // spills to overflow
+  EXPECT_EQ(q.length(), 3u);
+  EXPECT_EQ(q.pop(), std::make_tuple(1, false));
+  EXPECT_EQ(q.pop(), std::make_tuple(2, false));
+  EXPECT_EQ(q.pop(), std::make_tuple(3, true));  // last
+  EXPECT_TRUE(q.is_empty());
+}
+
+TEST(BQueue, OverflowStickyPreservesOrder) {
+  BQueue<int> q(1);
+  for (int i = 0; i < 10; ++i) q.push(i);
+  for (int i = 0; i < 10; ++i) {
+    auto [v, last] = q.pop();
+    EXPECT_EQ(v, i);
+    EXPECT_EQ(last, i == 9);
+  }
+}
+
+// ---- batched-drain scenarios ----
+
+TEST(BQueue, PopBatchDrainsRingFifo) {
+  BQueue<int> q(8);
+  for (int i = 0; i < 5; ++i) q.push(i);
+  std::vector<int> out;
+  q.pop_batch(out);
+  EXPECT_EQ(out, (std::vector<int>{0, 1, 2, 3, 4}));
+  EXPECT_TRUE(q.is_empty());
+}
+
+TEST(BQueue, PopBatchDrainsRingThenOverflowFifo) {
+  // cap 2: 0,1 in ring; 2,3,4 spill to overflow. One drain returns all five
+  // in order (ring first, then overflow).
+  BQueue<int> q(2);
+  for (int i = 0; i < 5; ++i) q.push(i);
+  std::vector<int> out;
+  q.pop_batch(out);
+  EXPECT_EQ(out, (std::vector<int>{0, 1, 2, 3, 4}));
+  EXPECT_TRUE(q.is_empty());
+}
+
+TEST(BQueue, PopBatchClearsOutParam) {
+  BQueue<int> q(4);
+  q.push(42);
+  std::vector<int> out{7, 8, 9};  // stale contents must be discarded
+  q.pop_batch(out);
+  EXPECT_EQ(out, (std::vector<int>{42}));
+}
+
+TEST(BQueue, PopBatchReturnsOnlyCurrentlyQueued) {
+  BQueue<int> q(8);
+  q.push(1);
+  q.push(2);
+  std::vector<int> out;
+  q.pop_batch(out);
+  EXPECT_EQ(out, (std::vector<int>{1, 2}));
+  q.push(3);  // arrived after the drain
+  q.pop_batch(out);
+  EXPECT_EQ(out, (std::vector<int>{3}));
+}
+
+TEST(BQueue, PopBatchBlocksUntilPushedThenWakes) {
+  // A consumer blocked in pop_batch on an empty queue must be woken by a push
+  // into the empty queue (exercises the transition-notify path).
+  BQueue<int> q(4);
+  std::vector<int> got;
+  std::thread consumer([&] { q.pop_batch(got); });
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));  // let it park
+  q.push(99);
+  consumer.join();
+  EXPECT_EQ(got, (std::vector<int>{99}));
+}
+
+TEST(BQueue, ConcurrentProducerConsumerInOrder) {
+  // Single producer streams 0..N; single consumer drains via pop_batch. Every
+  // item must arrive exactly once, in order. Stresses the transition-notify
+  // wakeup under a real backlog/drain race.
+  constexpr int N = 200000;
+  BQueue<int> q(1024);
+  std::thread producer([&] {
+    for (int i = 0; i < N; ++i) q.push(i);
+  });
+  int expect = 0;
+  std::vector<int> buf;
+  while (expect < N) {
+    q.pop_batch(buf);
+    for (int v : buf) {
+      ASSERT_EQ(v, expect);
+      ++expect;
+    }
+  }
+  producer.join();
+  EXPECT_EQ(expect, N);
+}

--- a/actors/cpp/tests/test_lockfree_mpsc.cpp
+++ b/actors/cpp/tests/test_lockfree_mpsc.cpp
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2026 Vincent Mayeski / M2 Tech (16425640 Canada Inc.).
+ * Contact: v@m2te.ch | https://www.linkedin.com/in/vmayeski/
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root.
+ *
+ * LockFreeMPSC tests: no-loss/no-dup (incl. many concurrent producers), ring
+ * wraparound reuse, the full-ring-then-drain path (push must unblock when the
+ * consumer frees a slot), the pop_batch per-call drain cap (must RETURN under a
+ * flood instead of looping unbounded), capacity rounding, and the park/wake path.
+ */
+
+#include <gtest/gtest.h>
+#include <vector>
+#include <thread>
+#include <atomic>
+#include <chrono>
+#include <tuple>
+#include "actors/LockFreeMPSC.hpp"
+
+using actors::LockFreeMPSC;
+using namespace std::chrono_literals;
+
+static constexpr size_t MAX_DRAIN = 8192;  // must match LockFreeMPSC::kMaxDrain
+
+TEST(LockFreeMPSC, DrainsAllNoLoss) {
+  LockFreeMPSC<int> q(1024);
+  for (int i = 0; i < 500; ++i) q.push(i);
+  EXPECT_EQ(q.length(), 500u);
+  std::vector<int> out;
+  q.pop_batch(out);
+  ASSERT_EQ(out.size(), 500u);
+  for (int i = 0; i < 500; ++i) EXPECT_EQ(out[i], i);   // MPSC single producer => FIFO
+  EXPECT_TRUE(q.is_empty());
+}
+
+TEST(LockFreeMPSC, SinglePopRetrievesEverythingInOrder) {
+  LockFreeMPSC<int> q(64);
+  for (int i = 0; i < 20; ++i) q.push(i);
+  for (int i = 0; i < 20; ++i) {
+    auto [v, last] = q.pop();
+    EXPECT_EQ(v, i);
+    EXPECT_EQ(last, i == 19);
+  }
+  EXPECT_TRUE(q.is_empty());
+}
+
+TEST(LockFreeMPSC, WrapAroundReuseNoLoss) {
+  // Small ring, push then pop in lockstep so the ring stays shallow but the
+  // position advances far past capacity => cells are reused (sequence wrap).
+  LockFreeMPSC<int> q(8);
+  for (int i = 0; i < 100000; ++i) {          // 100k >> capacity 8 => ~12.5k wraps
+    q.push(i);
+    auto [v, last] = q.pop();
+    EXPECT_EQ(v, i);
+    EXPECT_TRUE(last);                          // depth returns to 0 each round
+  }
+  EXPECT_TRUE(q.is_empty());
+}
+
+TEST(LockFreeMPSC, ManyProducersNoLossNoDup) {
+  constexpr int P = 8, K = 100000;
+  constexpr long TOTAL = (long)P * K;
+  LockFreeMPSC<int> q(1 << 20);
+  std::vector<std::thread> prod;
+  for (int p = 0; p < P; ++p)
+    prod.emplace_back([&q, p] { for (int i = 0; i < K; ++i) q.push(p * K + i); });
+  std::vector<char> seen(TOTAL, 0);
+  long recv = 0; std::vector<int> buf;
+  while (recv < TOTAL) {
+    q.pop_batch(buf);
+    for (int v : buf) { ASSERT_GE(v, 0); ASSERT_LT(v, TOTAL); ASSERT_FALSE(seen[v]); seen[v] = 1; ++recv; }
+  }
+  for (auto& t : prod) t.join();
+  EXPECT_EQ(recv, TOTAL);
+}
+
+// #4: push() must not spin forever on a full ring — it unblocks once the consumer
+// frees a slot.
+TEST(LockFreeMPSC, PushBlocksWhenFullThenUnblocks) {
+  LockFreeMPSC<int> q(8);                 // capacity 8
+  for (int i = 0; i < 8; ++i) q.push(i);  // ring now full
+  std::atomic<bool> pushed{false};
+  std::thread producer([&] { q.push(999); pushed.store(true); });  // blocks: ring full
+  std::this_thread::sleep_for(50ms);
+  EXPECT_FALSE(pushed.load()) << "push should still be blocked on a full ring";
+  std::vector<int> out;
+  q.pop_batch(out);                       // frees slots
+  producer.join();
+  EXPECT_TRUE(pushed.load());             // push completed once space appeared
+}
+
+// #5: pop_batch must RETURN even when producers flood faster than we drain. We
+// prove the per-call cap directly: push more than the cap, one call returns the
+// cap, the rest come on the next call (no loss, no unbounded batch).
+TEST(LockFreeMPSC, PopBatchIsBounded) {
+  LockFreeMPSC<int> q(1 << 15);
+  const size_t N = MAX_DRAIN + 4096;
+  for (size_t i = 0; i < N; ++i) q.push((int)i);
+  std::vector<int> out;
+  q.pop_batch(out);
+  EXPECT_EQ(out.size(), MAX_DRAIN) << "pop_batch must cap the batch, not drain everything";
+  std::vector<int> rest;
+  q.pop_batch(rest);
+  EXPECT_EQ(out.size() + rest.size(), N);   // no loss across the two calls
+}
+
+TEST(LockFreeMPSC, CapacityRoundsUpToPowerOfTwo) {
+  LockFreeMPSC<int> q(5);                  // rounds up to 8
+  for (int i = 0; i < 8; ++i) q.push(i);   // must accept at least 8 without blocking
+  EXPECT_EQ(q.length(), 8u);
+  LockFreeMPSC<int> q0(0);                 // degenerate: rounds to 1
+  q0.push(42);
+  auto [v, last] = q0.pop();
+  EXPECT_EQ(v, 42); EXPECT_TRUE(last);
+}
+
+TEST(LockFreeMPSC, PopBatchBlocksUntilPushedThenWakes) {
+  LockFreeMPSC<int> q(64);
+  std::vector<int> got;
+  std::thread consumer([&] { q.pop_batch(got); });   // parks: empty
+  std::this_thread::sleep_for(50ms);
+  q.push(7);
+  consumer.join();
+  ASSERT_EQ(got.size(), 1u);
+  EXPECT_EQ(got[0], 7);
+}

--- a/actors/cpp/tests/test_sharded_bqueue.cpp
+++ b/actors/cpp/tests/test_sharded_bqueue.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2026 Vincent Mayeski / M2 Tech (16425640 Canada Inc.).
+ * Contact: v@m2te.ch | https://www.linkedin.com/in/vmayeski/
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root.
+ *
+ * ShardedBQueue tests. Round-robin sharding does NOT preserve FIFO order, so the
+ * correctness properties are: (1) no message lost or duplicated, and (2) the
+ * consumer wakes when a producer pushes into an empty queue. The headline test
+ * is many concurrent producers -> one consumer with zero loss/dup, which is the
+ * high-contention case the sharded mailbox exists for.
+ */
+
+#include <gtest/gtest.h>
+#include <vector>
+#include <thread>
+#include <chrono>
+#include <tuple>
+#include "actors/ShardedBQueue.hpp"
+
+using actors::ShardedBQueue;
+
+TEST(ShardedBQueue, DrainsAllItemsNoLoss) {
+  ShardedBQueue<int> q(8);
+  for (int i = 0; i < 100; ++i) q.push(i);
+  EXPECT_EQ(q.length(), 100u);
+  std::vector<int> out;
+  q.pop_batch(out);
+  ASSERT_EQ(out.size(), 100u);
+  std::vector<char> seen(100, 0);
+  for (int v : out) { ASSERT_GE(v, 0); ASSERT_LT(v, 100); EXPECT_FALSE(seen[v]); seen[v] = 1; }
+  EXPECT_TRUE(q.is_empty());
+}
+
+TEST(ShardedBQueue, SinglePopRetrievesEverything) {
+  ShardedBQueue<int> q(4);
+  for (int i = 0; i < 20; ++i) q.push(i);
+  std::vector<char> seen(20, 0);
+  for (int i = 0; i < 20; ++i) {
+    auto [v, last] = q.pop();
+    ASSERT_GE(v, 0); ASSERT_LT(v, 20);
+    EXPECT_FALSE(seen[v]); seen[v] = 1;
+    EXPECT_EQ(last, i == 19);  // last == queue now empty
+  }
+  EXPECT_TRUE(q.is_empty());
+}
+
+TEST(ShardedBQueue, PopBatchBlocksUntilPushedThenWakes) {
+  ShardedBQueue<int> q(8);
+  std::vector<int> got;
+  std::thread consumer([&] { q.pop_batch(got); });
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));  // let it park
+  q.push(99);
+  consumer.join();
+  ASSERT_EQ(got.size(), 1u);
+  EXPECT_EQ(got[0], 99);
+}
+
+TEST(ShardedBQueue, ManyProducersNoLossNoDup) {
+  // 8 producers hammering one 8-lane mailbox; one consumer drains via pop_batch.
+  // Every value must arrive exactly once (order is not guaranteed).
+  constexpr int P = 8;
+  constexpr int K = 100000;
+  constexpr long TOTAL = (long)P * K;
+  ShardedBQueue<int> q(8);
+
+  std::vector<std::thread> producers;
+  for (int p = 0; p < P; ++p) {
+    producers.emplace_back([&q, p] {
+      for (int i = 0; i < K; ++i) q.push(p * K + i);  // globally unique value
+    });
+  }
+
+  std::vector<char> seen(TOTAL, 0);
+  long received = 0;
+  std::vector<int> buf;
+  while (received < TOTAL) {
+    q.pop_batch(buf);
+    for (int v : buf) {
+      ASSERT_GE(v, 0); ASSERT_LT(v, TOTAL);
+      ASSERT_FALSE(seen[v]) << "duplicate value " << v;
+      seen[v] = 1;
+      ++received;
+    }
+  }
+  for (auto& t : producers) t.join();
+  EXPECT_EQ(received, TOTAL);
+  EXPECT_TRUE(q.is_empty());
+}

--- a/actors/cpp/tests/test_sharded_bqueue.cpp
+++ b/actors/cpp/tests/test_sharded_bqueue.cpp
@@ -87,3 +87,40 @@ TEST(ShardedBQueue, ManyProducersNoLossNoDup) {
   EXPECT_EQ(received, TOTAL);
   EXPECT_TRUE(q.is_empty());
 }
+
+// pop_batch must RETURN under a flood instead of looping forever while `out`
+// grows unbounded. Prove the per-call cap directly.
+TEST(ShardedBQueue, PopBatchIsBounded) {
+  constexpr size_t MAX_DRAIN = 8192;   // must match ShardedBQueue::kMaxDrain
+  ShardedBQueue<int> q(8);
+  const size_t N = MAX_DRAIN + 4096;
+  for (size_t i = 0; i < N; ++i) q.push((int)i);
+  std::vector<int> out;
+  q.pop_batch(out);
+  EXPECT_EQ(out.size(), MAX_DRAIN) << "pop_batch must cap the batch, not drain everything";
+  std::vector<int> rest;
+  q.pop_batch(rest);
+  EXPECT_EQ(out.size() + rest.size(), N);   // no loss across the two calls
+}
+
+// Exercises the park/wake handshake (the seq_cst fence fix): a producer that
+// pushes one-at-a-time with pauses forces the consumer to park repeatedly; every
+// message must still arrive (no lost wakeup, no loss/dup).
+TEST(ShardedBQueue, ParkWakeStressNoLoss) {
+  constexpr int N = 20000;
+  ShardedBQueue<int> q(8);
+  std::thread producer([&] {
+    for (int i = 0; i < N; ++i) {
+      q.push(i);
+      if (i % 500 == 0) std::this_thread::sleep_for(std::chrono::microseconds(200)); // let consumer park
+    }
+  });
+  std::vector<char> seen(N, 0);
+  int recv = 0; std::vector<int> buf;
+  while (recv < N) {
+    q.pop_batch(buf);
+    for (int v : buf) { ASSERT_GE(v, 0); ASSERT_LT(v, N); ASSERT_FALSE(seen[v]); seen[v] = 1; ++recv; }
+  }
+  producer.join();
+  EXPECT_EQ(recv, N);
+}

--- a/actors/rust/examples/ping_pong_batch.rs
+++ b/actors/rust/examples/ping_pong_batch.rs
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 Vincent Mayeski / M2 Tech (16425640 Canada Inc.).
+// Contact: v@m2te.ch | https://www.linkedin.com/in/vmayeski/
+//
+// Licensed under the MIT License. See LICENSE file in the project root.
+
+//! Batched async ping-pong — Ping fires a burst of BATCH messages at Pong before
+//! waiting for any reply, so both mailboxes go deep (~BATCH backlog). This is the
+//! workload where BQueue batch-drain (one lock + one notify per burst instead of
+//! per message) is supposed to pay off. Contrast with `ping_pong` (depth-1).
+//!
+//! Run: `cargo run --release --example ping_pong_batch`
+
+use actors::{define_message, handle_messages, ActorContext, ActorRef, Manager, ManagerHandle, Start, ThreadConfig};
+
+const BATCH: i32 = 10_000; // messages sent per burst
+const ROUNDS: i32 = 1_000; // number of bursts  => BATCH*ROUNDS round-trips
+
+struct Ping {
+    count: i32,
+}
+define_message!(Ping, 10);
+
+struct Pong {
+    count: i32,
+}
+define_message!(Pong, 11);
+
+struct PingActor {
+    pong: ActorRef,
+    handle: ManagerHandle,
+    recv: i32,
+    bursts_sent: i32,
+}
+impl PingActor {
+    fn fire(&mut self, ctx: &mut ActorContext) {
+        for _ in 0..BATCH {
+            self.pong.send(Box::new(Ping { count: 1 }), ctx.self_ref());
+        }
+        self.bursts_sent += 1;
+    }
+    fn on_start(&mut self, _m: &Start, ctx: &mut ActorContext) {
+        self.fire(ctx);
+    }
+    fn on_pong(&mut self, _m: &Pong, ctx: &mut ActorContext) {
+        self.recv += 1;
+        if self.recv >= BATCH * ROUNDS {
+            self.handle.terminate();
+            return;
+        }
+        // once a full burst has come back, launch the next one
+        if self.recv % BATCH == 0 && self.bursts_sent < ROUNDS {
+            self.fire(ctx);
+        }
+    }
+}
+handle_messages!(PingActor, Start => on_start, Pong => on_pong);
+
+struct PongActor;
+impl PongActor {
+    fn on_ping(&mut self, m: &Ping, ctx: &mut ActorContext) {
+        ctx.reply(Box::new(Pong { count: m.count }));
+    }
+}
+handle_messages!(PongActor, Ping => on_ping);
+
+fn main() {
+    let total = (BATCH as i64) * (ROUNDS as i64);
+    println!("=== batched ping-pong: burst={BATCH}, bursts={ROUNDS}, round-trips={total} ===");
+    let mut mgr = Manager::new();
+    let handle = mgr.get_handle();
+
+    let pong = mgr.manage("Pong", Box::new(PongActor), ThreadConfig::default());
+    let ping = PingActor { pong, handle, recv: 0, bursts_sent: 0 };
+    let _ping_ref = mgr.manage("Ping", Box::new(ping), ThreadConfig::default());
+
+    let t0 = std::time::Instant::now();
+    mgr.init();
+    mgr.run();
+    let elapsed = t0.elapsed();
+    mgr.end();
+
+    let msgs = (total * 2) as f64; // pings + pongs
+    println!(
+        "{total} round-trips in {:.3?}  ({:.2} M round-trips/s, {:.1} M msgs/s)",
+        elapsed,
+        total as f64 / elapsed.as_secs_f64() / 1e6,
+        msgs / elapsed.as_secs_f64() / 1e6,
+    );
+}

--- a/actors/rust/src/actor.rs
+++ b/actors/rust/src/actor.rs
@@ -199,19 +199,22 @@ pub(crate) fn run_actor(cell: Arc<ActorCell>) {
         guard.init(&mut ctx);
     }
 
+    // Lever 1: drain the whole mailbox in one lock. Lever 2: take the per-actor
+    // lock ONCE for the whole drained batch instead of per message. NOTE: the
+    // per-actor lock is shared with fast_send, so a fast_send to this actor waits
+    // for the batch to finish — acceptable here, but see the writeup's caveat.
+    let mut batch: Vec<Envelope> = Vec::new();
     while cell.running.load(Ordering::Relaxed) {
-        let (env, _last) = cell.queue.pop();
-        let is_shutdown = env.msg.message_id() == crate::messages::Shutdown::ID;
-
-        {
+        cell.queue.pop_batch(&mut batch);
+        let mut guard = cell.actor.lock().unwrap_or_else(|e| e.into_inner());
+        for env in batch.drain(..) {
+            let is_shutdown = env.msg.message_id() == crate::messages::Shutdown::ID;
             let mut ctx = ActorContext::new(env.sender, Some(&self_ref), false);
-            let mut guard = cell.actor.lock().unwrap_or_else(|e| e.into_inner());
             guard.process_message(env.msg.as_message(), &mut ctx);
-        }
-
-        if is_shutdown {
-            cell.running.store(false, Ordering::Relaxed);
-            break;
+            if is_shutdown {
+                cell.running.store(false, Ordering::Relaxed);
+                break;
+            }
         }
     }
 

--- a/actors/rust/src/queue.rs
+++ b/actors/rust/src/queue.rs
@@ -46,15 +46,39 @@ impl<T> BQueue<T> {
 
     /// Push a value (never blocks, never drops). Overflow-sticky, like C++.
     pub fn push(&self, x: T) {
-        {
+        let was_empty = {
             let mut g = self.inner.lock().unwrap();
+            let empty = g.ring.is_empty() && g.overflow.is_empty();
             if !g.overflow.is_empty() || g.ring.len() >= self.cap {
                 g.overflow.push_back(x);
             } else {
                 g.ring.push_back(x);
             }
+            empty
+        };
+        // The consumer only sleeps (cv.wait) when it finds the queue empty under
+        // the lock, so the only push that must signal is the one that makes an
+        // empty queue non-empty. Skips a syscall on every push into a backlog.
+        if was_empty {
+            self.cv.notify_one();
         }
-        self.cv.notify_one();
+    }
+
+    /// Batch-blocking drain. Blocks until >=1 item, then moves the ENTIRE queue
+    /// (ring then overflow, FIFO) into `out` under a single lock. N queued
+    /// messages cost one lock acquisition instead of N. Returns nothing; `out`
+    /// is cleared first.
+    pub fn pop_batch(&self, out: &mut Vec<T>) {
+        out.clear();
+        let mut g = self.inner.lock().unwrap();
+        loop {
+            if !g.ring.is_empty() || !g.overflow.is_empty() {
+                out.extend(g.ring.drain(..));
+                out.extend(g.overflow.drain(..));
+                return;
+            }
+            g = self.cv.wait(g).unwrap();
+        }
     }
 
     /// Blocking pop. Returns `(value, last)` where `last` means the queue is now
@@ -115,5 +139,109 @@ mod tests {
             assert_eq!(v, i);
             assert_eq!(last, i == 9);
         }
+    }
+
+    // ---- batched-drain scenarios ----
+
+    #[test]
+    fn pop_batch_drains_ring_in_fifo() {
+        let q = BQueue::new(8);
+        for i in 0..5 {
+            q.push(i);
+        }
+        let mut out = Vec::new();
+        q.pop_batch(&mut out);
+        assert_eq!(out, vec![0, 1, 2, 3, 4]);
+        assert!(q.is_empty());
+    }
+
+    #[test]
+    fn pop_batch_drains_ring_then_overflow_fifo() {
+        // cap 2: 0,1 in ring; 2,3,4 spill to overflow. One drain must return
+        // all five in order (ring first, then overflow).
+        let q = BQueue::new(2);
+        for i in 0..5 {
+            q.push(i);
+        }
+        let mut out = Vec::new();
+        q.pop_batch(&mut out);
+        assert_eq!(out, vec![0, 1, 2, 3, 4]);
+        assert!(q.is_empty());
+    }
+
+    #[test]
+    fn pop_batch_clears_out_param() {
+        let q = BQueue::new(4);
+        q.push(42);
+        let mut out = vec![7, 8, 9]; // stale contents must be discarded
+        q.pop_batch(&mut out);
+        assert_eq!(out, vec![42]);
+    }
+
+    #[test]
+    fn pop_batch_returns_only_currently_queued() {
+        let q = BQueue::new(8);
+        q.push(1);
+        q.push(2);
+        let mut out = Vec::new();
+        q.pop_batch(&mut out);
+        assert_eq!(out, vec![1, 2]);
+        q.push(3); // arrived after the drain
+        q.pop_batch(&mut out);
+        assert_eq!(out, vec![3]);
+    }
+
+    #[test]
+    fn pop_batch_blocks_until_pushed_then_wakes() {
+        // A consumer blocked in pop_batch on an empty queue must be woken by a
+        // push into the empty queue (exercises the transition-notify path).
+        use std::sync::Arc;
+        use std::thread;
+        use std::time::Duration;
+
+        let q = Arc::new(BQueue::new(4));
+        let qc = Arc::clone(&q);
+        let h = thread::spawn(move || {
+            let mut out = Vec::new();
+            qc.pop_batch(&mut out); // blocks until producer pushes
+            out
+        });
+        thread::sleep(Duration::from_millis(50)); // ensure consumer is parked
+        q.push(99);
+        let got = h.join().unwrap();
+        assert_eq!(got, vec![99]);
+    }
+
+    #[test]
+    fn concurrent_producer_consumer_in_order() {
+        // Single producer streams 0..N; single consumer drains via pop_batch.
+        // Every item must arrive exactly once, in order. Stresses the
+        // transition-notify wakeup under a real backlog/drain race.
+        use std::sync::Arc;
+        use std::thread;
+
+        const N: i32 = 200_000;
+        let q = Arc::new(BQueue::new(1024));
+        let qp = Arc::clone(&q);
+        let producer = thread::spawn(move || {
+            for i in 0..N {
+                qp.push(i);
+            }
+        });
+        let qc = Arc::clone(&q);
+        let consumer = thread::spawn(move || {
+            let mut expect = 0;
+            let mut buf = Vec::new();
+            while expect < N {
+                qc.pop_batch(&mut buf);
+                for &v in &buf {
+                    assert_eq!(v, expect);
+                    expect += 1;
+                }
+            }
+            expect
+        });
+        producer.join().unwrap();
+        assert_eq!(consumer.join().unwrap(), N);
     }
 }


### PR DESCRIPTION
Single combined PR for the mailbox work (batch drain + the two new mailbox
implementations). **Not for merge** until manually tested — kept on the
`sharded-mailbox` experimental branch.

Contains:
- Consumer-side **batch drain** for BQueue (C++ & Rust): pop_batch, transition-notify,
  actor run loop drains once per batch. ~1.6x, 2.46x with the MemoryPool.
- **ShardedBQueue** (N mutex lanes, round-robin) and **LockFreeMPSC** (bounded Vyukov
  ring), selectable per actor via the `Actor(Queue*)` constructor. Default stays BQueue.
- `MAILBOXES.md` + README selection matrix.
- Review pass fixed: transition-notify seq_cst fence (both sides), full-ring cpu_relax,
  pop_batch drain cap, mid-batch-terminate leak. 24 tests green (queue + actor-level,
  incl. a DefaultMailboxIsBQueue guard).

Supersedes #19 (folded in here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)