### PR TITLE
mcast_recv: read Metamako hardware-timestamp trailer in PCAPReader

### DIFF
--- a/interface/mcast_recv/if/PCAPReader.hpp
+++ b/interface/mcast_recv/if/PCAPReader.hpp
@@ -14,14 +14,16 @@ actor_ptr create_PCAPReader_32_0(
     const std::string &_chan_nam,
     actor_ptr _msg_processor,
     const std::string &_pcap_filename,
-    bool _big_endian = false
+    bool _big_endian = false,
+    const mcast_recv::TrailerSpec &_trailer_spec = mcast_recv::TrailerSpec{}
     )
 {
     return new mcast_recv::PCAPReader<uint32_t, 0>(
         _chan_nam,
         _msg_processor,
         _pcap_filename,
-        _big_endian
+        _big_endian,
+        _trailer_spec
     );
 }
 
@@ -29,13 +31,15 @@ actor_ptr create_PCAPReader_64_10(
     const std::string &_chan_nam,
     actor_ptr _msg_processor,
     const std::string &_pcap_filename,
-    bool _big_endian = false
+    bool _big_endian = false,
+    const mcast_recv::TrailerSpec &_trailer_spec = mcast_recv::TrailerSpec{}
     )
 {
     return new mcast_recv::PCAPReader<uint64_t, 10>(
         _chan_nam,
         _msg_processor,
         _pcap_filename,
-        _big_endian
+        _big_endian,
+        _trailer_spec
     );
 }

--- a/interface/mdp3/if/mdp3.hpp
+++ b/interface/mdp3/if/mdp3.hpp
@@ -134,7 +134,8 @@ create_all_mdp3_pcap(
     bool disable_mbo,
     uint32_t max_mbp_level,
     bool debug_decoder,
-    int spinbuf
+    int spinbuf,
+    const mcast_recv::TrailerSpec &_trailer_spec = mcast_recv::TrailerSpec{}
     )
 {
     std::cerr << "create_all_mdp3_pcap" << std::endl;
@@ -169,7 +170,8 @@ create_all_mdp3_pcap(
             _chan_nam,
             msg_buf_a,
             _pcap_file_a,
-            false);  // big_endian
+            false,           // big_endian
+            _trailer_spec);  // hardware-timestamp trailer layout (None by default)
     }
 
     if (!_pcap_file_b.empty()) {
@@ -177,7 +179,8 @@ create_all_mdp3_pcap(
             _chan_nam,
             msg_buf_a,
             _pcap_file_b,
-            false);  // big_endian
+            false,           // big_endian
+            _trailer_spec);  // hardware-timestamp trailer layout (None by default)
     }
 
     return std::vector<cfsmp>{

--- a/mcast_recv/include/mcast_recv/act/PCAPReader.hpp
+++ b/mcast_recv/include/mcast_recv/act/PCAPReader.hpp
@@ -17,6 +17,7 @@
 #include "actors/msg/ShutdownThisActor.hpp"
 #include "actors/msg/Continue.hpp"
 #include "mcast_recv/message_buffer.hpp"
+#include "mcast_recv/trailer.hpp"
 #include "mcast_recv/msg/ProcessQ.hpp"
 #include "logger/act/Logger.hpp"
 
@@ -39,6 +40,8 @@ namespace mcast_recv
     std::string pcap_file;
     const uint8_t seq_num_offset = N; // for CME MDP3 its 0
     bool big_endian;
+    TrailerSpec trailer_spec;      // hardware-timestamp trailer layout (default: None)
+    bool trailer_validated = false; // first-packet config-vs-wire sanity check done
 
     pcap_t *pcap = nullptr;
     uint64_t packet_count = 0;
@@ -111,6 +114,7 @@ namespace mcast_recv
 
       // Parse IP header
       uint32_t ip_header_len = 0;
+      uint32_t ip_total_len = 0;
       uint32_t src_ip = 0;
       uint32_t ip_start = offset;
 
@@ -121,6 +125,9 @@ namespace mcast_recv
         }
         uint8_t ihl = (packet[offset] & 0x0F);
         ip_header_len = ihl * 4;
+        uint16_t tot_len_be;
+        memcpy(&tot_len_be, packet + ip_start + 2, 2);  // IPv4 Total Length at byte 2, network byte order
+        ip_total_len = ntohs(tot_len_be);
         memcpy(&src_ip, packet + ip_start + 12, 4);  // src IP at byte 12 of IPv4 header, network byte order
 
       } else if (ethertype == 0x86DD) {
@@ -143,12 +150,42 @@ namespace mcast_recv
 
       offset += 8; // Skip UDP header
 
-      // UDP payload
+      // Any hardware-timestamp trailer (e.g. Metamako) is appended to the L2
+      // frame *after* the UDP payload, so it must be excluded from the MDP3
+      // payload we hand to the decoder.
+      const uint32_t trailer_size = trailer_spec.present() ? trailer_spec.size : 0;
+      if (caplen < offset + trailer_size) {
+        ERRF(boost::format("Packet too small for UDP payload + trailer: %u bytes (offset=%u, trailer=%u)")
+             % caplen % offset % trailer_size);
+      }
+
+      // UDP payload (trailer excluded)
       const u_char *udp_payload = packet + offset;
-      uint32_t payload_len = caplen - offset;
+      uint32_t payload_len = caplen - offset - trailer_size;
 
       if (payload_len > mcast_recv::msgsz) {
         ERRF(boost::format("Payload too large: %u bytes (max %zu)") % payload_len % mcast_recv::msgsz);
+      }
+
+      // Extract the hardware capture timestamp from the trailer, if configured.
+      uint64_t hw_ts = 0;
+      if (trailer_spec.present()) {
+        const u_char *trailer = packet + caplen - trailer_size;
+        hw_ts = trailer_timestamp_ns(trailer, trailer_spec);
+
+        // On the first packet, verify the configured trailer actually matches
+        // the wire, so a mis-configuration fails loudly instead of silently
+        // corrupting payloads / timestamps.
+        if (!trailer_validated) {
+          const uint32_t frame_wo_trailer = ip_start + ip_total_len;
+          const uint64_t pcap_secs = timestamp_ns / 1000000000ULL;
+          if (!trailer_looks_valid(caplen, frame_wo_trailer, hw_ts / 1000000000ULL, pcap_secs, trailer_spec)) {
+            ERRF(boost::format("Trailer config does not match wire in '%s': caplen=%u, eth+ip_total=%u+%u, "
+                               "trailer_secs=%lu, pcap_secs=%lu")
+                 % pcap_file % caplen % ip_start % ip_total_len % (hw_ts / 1000000000ULL) % pcap_secs);
+          }
+          trailer_validated = true;
+        }
       }
 
       // MDP3 UDP payload: first 4 bytes are MsgSeqNum (uint32, little-endian)
@@ -163,7 +200,8 @@ namespace mcast_recv
       msg->buf.src_ip = src_ip;
       msg->buf.dst_port = dst_port;
       msg->buf.chan = 'A';  // Databento data is de-duplicated, always use Feed A
-      msg->buf.recv_ts = timestamp_ns;  // Use PCAP capture timestamp
+      msg->buf.recv_ts = timestamp_ns;  // software (pcap record header) capture ts
+      msg->buf.hw_ts = hw_ts;           // hardware (trailer) capture ts, 0 if no trailer configured
       if (packet_count < 3)
           std::cerr << "[PCAPReader] file=" << pcap_file << " pkt#" << packet_count << " mdp3_seqnum=" << mdp3_seqnum << "\n";
       last_mdp3_seqnum = mdp3_seqnum;
@@ -178,11 +216,13 @@ namespace mcast_recv
         const std::string &chan_nam,
         actors::Actor *msg_processor,
         const std::string &pcap_filename,
-        bool big_endian = false)
+        bool big_endian = false,
+        const TrailerSpec &trailer_spec = TrailerSpec{})
         : chan_nam(chan_nam),
           msg_processor(msg_processor),
           pcap_file(pcap_filename),
-          big_endian(big_endian)
+          big_endian(big_endian),
+          trailer_spec(trailer_spec)
     {
       snprintf(name, sizeof(name), "%sPCAPReader", chan_nam.c_str());
 

--- a/mcast_recv/include/mcast_recv/message_buffer.hpp
+++ b/mcast_recv/include/mcast_recv/message_buffer.hpp
@@ -19,7 +19,8 @@ namespace mcast_recv
         uint32_t seqnum;
         std::array<char, msgsz> message;
         std::size_t len;
-        uint64_t recv_ts;
+        uint64_t recv_ts;  // software capture ts (pcap record header / socket clock), ns since epoch
+        uint64_t hw_ts;    // hardware capture ts from NIC/tap trailer (e.g. Metamako), ns since epoch; 0 = not present
         char chan;
         uint32_t src_ip;   // IPv4 source address, network byte order
         uint16_t dst_port; // UDP destination port, host byte order

--- a/mcast_recv/include/mcast_recv/trailer.hpp
+++ b/mcast_recv/include/mcast_recv/trailer.hpp
@@ -1,0 +1,84 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026 Vincent Mayeski / M2 Tech (16425640 Canada Inc.).
+ * Contact: v@m2te.ch | https://www.linkedin.com/in/vmayeski/
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root.
+ */
+
+#include <cstdint>
+#include <cstring>
+#include <arpa/inet.h> // ntohl
+
+namespace mcast_recv
+{
+    // Vendor/layout of a hardware-timestamp trailer that some capture devices
+    // append to the Ethernet frame *after* the UDP payload. This is NOT part of
+    // the IP/UDP datagram (it lives beyond ip_total_len), so it only survives an
+    // L2 capture (pcap) -- a normal UDP socket never sees it.
+    enum class TrailerType : uint8_t
+    {
+        None = 0, // no trailer present
+        Metamako  // Metamako / Arista MetaWatch 20-byte trailer
+    };
+
+    // Describes where the hardware timestamp lives inside a trailer. Kept as data
+    // (not hard-coded in the reader) so other vendors/layouts can be added and so
+    // a reader can be configured per capture source.
+    struct TrailerSpec
+    {
+        TrailerType type = TrailerType::None;
+        uint16_t size = 0;           // total trailer length in bytes (Metamako: 20)
+        uint16_t seconds_offset = 0; // offset of the big-endian uint32 seconds field
+        uint16_t nanos_offset = 0;   // offset of the big-endian uint32 nanoseconds field
+
+        bool present() const noexcept { return type != TrailerType::None; }
+
+        // Canonical Metamako layout: 20-byte trailer, big-endian seconds at
+        // offset 8 and big-endian nanoseconds at offset 12.
+        static constexpr TrailerSpec metamako() noexcept
+        {
+            return TrailerSpec{TrailerType::Metamako, 20, 8, 12};
+        }
+    };
+
+    // Parse the hardware timestamp (ns since the Unix epoch) from a trailer whose
+    // first byte is at `trailer`. Caller guarantees >= spec.size readable bytes.
+    // Fields are big-endian (network order) per the Metamako format.
+    inline uint64_t trailer_timestamp_ns(const uint8_t *trailer, const TrailerSpec &spec) noexcept
+    {
+        uint32_t secs_be = 0;
+        uint32_t nanos_be = 0;
+        std::memcpy(&secs_be, trailer + spec.seconds_offset, sizeof(secs_be));
+        std::memcpy(&nanos_be, trailer + spec.nanos_offset, sizeof(nanos_be));
+        const uint64_t secs = ntohl(secs_be);
+        const uint64_t nanos = ntohl(nanos_be);
+        return secs * 1000000000ULL + nanos;
+    }
+
+    // Cheap sanity check that a *configured* trailer actually matches the wire,
+    // so a mis-configuration is caught loudly instead of silently corrupting
+    // data. Two conditions:
+    //   1. the captured frame is exactly `frame_len_without_trailer + spec.size`
+    //      bytes (i.e. there really are spec.size trailing bytes past the IP
+    //      payload), and
+    //   2. the trailer seconds are within `tolerance_s` of a reference clock
+    //      (e.g. the pcap record-header seconds).
+    inline bool trailer_looks_valid(
+        uint32_t caplen,
+        uint32_t frame_len_without_trailer,
+        uint64_t trailer_secs,
+        uint64_t reference_secs,
+        const TrailerSpec &spec,
+        uint64_t tolerance_s = 5) noexcept
+    {
+        if (!spec.present())
+            return false;
+        if (caplen != frame_len_without_trailer + spec.size)
+            return false;
+        const uint64_t diff =
+            trailer_secs > reference_secs ? trailer_secs - reference_secs : reference_secs - trailer_secs;
+        return diff <= tolerance_s;
+    }
+}

--- a/mcast_recv/tests/Makefile
+++ b/mcast_recv/tests/Makefile
@@ -1,0 +1,27 @@
+# Copyright (c) 2026 Vincent Mayeski / M2 Tech (16425640 Canada Inc.).
+#
+# Licensed under the MIT License. See LICENSE file in the project root.
+#
+# mcast_recv unit tests (Google Test). The trailer parser is header-only, so
+# the tests need only the include path -- no library link.
+#   make test   # build and run
+
+CXX ?= g++
+GTEST_PATH ?= /usr
+
+INCL = -I../include
+CXXFLAGS = -std=gnu++20 -O2 -W -Wall -Wextra $(INCL)
+
+TEST_SRC = $(wildcard test_*.cpp)
+TEST_BIN = run_tests
+
+test: $(TEST_BIN)
+	./$(TEST_BIN)
+
+$(TEST_BIN): $(TEST_SRC)
+	$(CXX) $(CXXFLAGS) $(TEST_SRC) -o $@ -L$(GTEST_PATH)/lib -lgtest -lgtest_main -lpthread
+
+clean:
+	rm -f $(TEST_BIN)
+
+.PHONY: test clean

--- a/mcast_recv/tests/test_trailer.cpp
+++ b/mcast_recv/tests/test_trailer.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026 Vincent Mayeski / M2 Tech (16425640 Canada Inc.).
+ * Contact: v@m2te.ch | https://www.linkedin.com/in/vmayeski/
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root.
+ *
+ * Unit tests for the hardware-timestamp trailer parser (mcast_recv/trailer.hpp).
+ * The "real capture" cases use bytes taken verbatim from the CME channel-310
+ * (ES) Metamako captures, so they pin the exact wire layout and endianness.
+ */
+
+#include <gtest/gtest.h>
+#include <cstdint>
+#include "mcast_recv/trailer.hpp"
+
+using mcast_recv::TrailerSpec;
+using mcast_recv::TrailerType;
+using mcast_recv::trailer_looks_valid;
+using mcast_recv::trailer_timestamp_ns;
+
+// Metamako trailer bytes from the first packet of the side-A (port 14310)
+// capture: secs (BE u32) @ offset 8 = 0x5d6806dc = 1567098588,
+//          nanos (BE u32) @ offset 12 = 0x13401888 = 322967688.
+static const uint8_t kRealTrailer[20] = {0xc4, 0x8b, 0xae, 0xf4, 0x00, 0xdf, 0x1e, 0x20, 0x5d, 0x68,
+                                         0x06, 0xdc, 0x13, 0x40, 0x18, 0x88, 0x03, 0x00, 0x28, 0x11};
+
+TEST(TrailerSpec, MetamakoDefaults)
+{
+    const TrailerSpec spec = TrailerSpec::metamako();
+    EXPECT_EQ(spec.type, TrailerType::Metamako);
+    EXPECT_TRUE(spec.present());
+    EXPECT_EQ(spec.size, 20u);
+    EXPECT_EQ(spec.seconds_offset, 8u);
+    EXPECT_EQ(spec.nanos_offset, 12u);
+}
+
+TEST(TrailerSpec, DefaultIsNone)
+{
+    const TrailerSpec spec;
+    EXPECT_EQ(spec.type, TrailerType::None);
+    EXPECT_FALSE(spec.present());
+    EXPECT_EQ(spec.size, 0u);
+}
+
+TEST(TrailerTimestamp, ParsesRealMetamakoCapture)
+{
+    const uint64_t ts = trailer_timestamp_ns(kRealTrailer, TrailerSpec::metamako());
+    EXPECT_EQ(ts, 1567098588ULL * 1000000000ULL + 322967688ULL);
+    EXPECT_EQ(ts, 1567098588322967688ULL);
+}
+
+TEST(TrailerTimestamp, BigEndianFieldsCraftedValue)
+{
+    // secs = 0x00000002 = 2, nanos = 0x00000003 = 3  (both big-endian)
+    uint8_t t[20] = {};
+    t[8] = 0x00; t[9] = 0x00; t[10] = 0x00; t[11] = 0x02;  // seconds
+    t[12] = 0x00; t[13] = 0x00; t[14] = 0x00; t[15] = 0x03; // nanos
+    EXPECT_EQ(trailer_timestamp_ns(t, TrailerSpec::metamako()), 2ULL * 1000000000ULL + 3ULL);
+}
+
+TEST(TrailerTimestamp, NanosNearOneSecondBoundary)
+{
+    // nanos = 999999999 = 0x3B9AC9FF, secs = 1
+    uint8_t t[20] = {};
+    t[11] = 0x01;                                                   // secs = 1
+    t[12] = 0x3B; t[13] = 0x9A; t[14] = 0xC9; t[15] = 0xFF;         // nanos = 999999999
+    EXPECT_EQ(trailer_timestamp_ns(t, TrailerSpec::metamako()), 1999999999ULL);
+}
+
+TEST(TrailerValidate, AcceptsWellFormedFrame)
+{
+    const TrailerSpec spec = TrailerSpec::metamako();
+    // caplen == eth+ip_total (142) + trailer (20) == 162; trailer secs == pcap secs.
+    EXPECT_TRUE(trailer_looks_valid(162, 142, 1567098588ULL, 1567098588ULL, spec));
+    // within tolerance
+    EXPECT_TRUE(trailer_looks_valid(162, 142, 1567098588ULL, 1567098590ULL, spec));
+}
+
+TEST(TrailerValidate, RejectsWrongFrameLength)
+{
+    const TrailerSpec spec = TrailerSpec::metamako();
+    // no 20 trailing bytes present -> caplen would be 142, not 162
+    EXPECT_FALSE(trailer_looks_valid(142, 142, 1567098588ULL, 1567098588ULL, spec));
+}
+
+TEST(TrailerValidate, RejectsImplausibleClock)
+{
+    const TrailerSpec spec = TrailerSpec::metamako();
+    // trailer seconds far from the reference (software) clock -> misconfigured/garbage
+    EXPECT_FALSE(trailer_looks_valid(162, 142, 1000000000ULL, 1567098588ULL, spec));
+}
+
+TEST(TrailerValidate, NoneSpecNeverValid)
+{
+    const TrailerSpec spec; // None
+    EXPECT_FALSE(trailer_looks_valid(162, 142, 1567098588ULL, 1567098588ULL, spec));
+}


### PR DESCRIPTION
## What
Make kaspar's PCAP reader able to correctly read captures carrying a **Metamako / Arista** hardware-timestamp trailer, and expose the hardware capture timestamp on the message.

## Why
The trailer is appended to the L2 frame **after** the UDP payload (beyond `ip_total_len`), so it survives only an L2 capture (pcap). Today `PCAPReader`:
- never reads it, and
- worse, sweeps the 20 trailer bytes into the MDP3 payload (`payload_len = caplen - offset`), handing garbage to the decoder.

It also carries only a **software** timestamp (`recv_ts`, from the pcap record header). Hardware (Metamako) timestamps are nanosecond, **per-side**, and jitter-free — the correct clock for feed arbitration. In the sample capture the software-vs-hardware gap is ~1.7 ms, which swamps the sub-µs A/B advantage.

## Changes
- **`message_buffer`**: new `hw_ts` field (ns since epoch; `0` = no trailer).
- **`trailer.hpp`** (new, header-only): `TrailerType` / `TrailerSpec` + big-endian parse (`secs@8`, `ns@12`) + a cheap **config-vs-wire validator**.
- **`PCAPReader`**: configurable `TrailerSpec` (defaults to `None` → **backward compatible**); excludes the trailer from the payload; fills `hw_ts`; validates the configured layout against the wire on the first packet so a misconfig fails loudly instead of corrupting data.
- Threaded `TrailerSpec` through the `PCAPReader` factories and the mdp3 pcap-playback wiring (all defaulted).
- **Tests** (`mcast_recv/tests/`, GoogleTest, `make test`): parser on **real capture bytes**, endianness, and validation — 9/9 pass.

## Notes
- Live `SocketReader` is intentionally unchanged: a `SOCK_DGRAM` socket never receives the trailer (the kernel strips bytes past the UDP length), so hardware timestamps there would require `SO_TIMESTAMPING`/`recvmsg` or a raw/`AF_PACKET` socket — out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)