### PR TITLE
build: make dependency paths overridable + add detect_paths.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,18 @@ Build and run the actor-framework unit tests:
 make -C actors/cpp test        # requires Google Test
 ```
 
+If your libraries live under a home-dir prefix (not `/usr` or `/usr/local`),
+auto-detect and export the paths:
+
+```bash
+eval "$(./mk_kaspr/detect_paths.sh)"     # or: ./mk_kaspr/detect_paths.sh --check
+```
+
 Notes:
 
-- External library paths are set in `mk_kaspr/glob_begin.mk` (`BOOST_PATH`,
-  `GSL_PATH`, `ZMQ_PATH`, …). Adjust them to match your system.
+- External library paths (`BOOST_PATH`, `GSL_PATH`, `ZMQ_PATH`, …) are
+  environment-overridable `?=` defaults in `mk_kaspr/glob_begin.mk` — set them
+  in your shell or run `detect_paths.sh`. See `mk_kaspr/PATHS.md`.
 - The Linux build targets x86-64 (`-mcx16`, `-mfpmath=sse`, `-march=native`);
   build on an x86-64 host (or under emulation).
 

--- a/actors/cpp/Makefile
+++ b/actors/cpp/Makefile
@@ -26,19 +26,22 @@ CONSOLE_SRC = src/console/Table.cpp src/console/ConsoleActor.cpp src/console/MQ0
 CXX = g++
 
 # OS detection
+# Dependency prefixes — overridable from the environment (`?=`, so a shell
+# export wins). Defaults match a vanilla system install; see mk_kaspr/PATHS.md
+# or run mk_kaspr/detect_paths.sh to auto-detect home-dir prefixes.
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
-    BOOST_PATH = /opt/homebrew/opt/boost
-    CPPZMQ_PATH = /opt/homebrew/opt/cppzmq
-    ZMQ_PATH = /opt/homebrew/opt/zeromq
-    JSON_PATH = /opt/homebrew/opt/nlohmann-json
-    GTEST_PATH = /opt/homebrew/opt/googletest
+    BOOST_PATH  ?= /opt/homebrew/opt/boost
+    CPPZMQ_PATH ?= /opt/homebrew/opt/cppzmq
+    ZMQ_PATH    ?= /opt/homebrew/opt/zeromq
+    JSON_PATH   ?= /opt/homebrew/opt/nlohmann-json
+    GTEST_PATH  ?= /opt/homebrew/opt/googletest
 else
-    BOOST_PATH = /home/vmayeski/local/boost190
-    CPPZMQ_PATH = /usr/local
-    ZMQ_PATH = /usr/local
-    JSON_PATH = /home/vmayeski/local
-    GTEST_PATH = /usr/local
+    BOOST_PATH  ?= /usr/local
+    CPPZMQ_PATH ?= /usr/local
+    ZMQ_PATH    ?= /usr/local
+    JSON_PATH   ?= /usr/local
+    GTEST_PATH  ?= /usr
 endif
 
 CXXFLAGS_COMMON = -std=c++20 -Iinclude -I../../chutil/include -I$(BOOST_PATH)/include -I$(CPPZMQ_PATH)/include -I$(ZMQ_PATH)/include -I$(JSON_PATH)/include -I$(GTEST_PATH)/include

--- a/mk_kaspr/PATHS.md
+++ b/mk_kaspr/PATHS.md
@@ -1,0 +1,103 @@
+<!--
+    Copyright (c) 2026 Vincent Mayeski / M2 Tech (16425640 Canada Inc.).
+    Licensed under the MIT License. See LICENSE file in the project root.
+-->
+
+# mk_kaspr — build-path environment variables
+
+`mk_kaspr/glob_begin.mk` (and `actors/cpp/Makefile`) no longer hardcode
+third-party library prefixes. Every externally-resolvable path uses GNU-make
+`?=` assignment, so setting the same variable in your shell environment
+overrides the default.
+
+## What's overridable
+
+| Variable | Points at | Default (Linux) | Default (macOS) |
+|----------|-----------|-----------------|-----------------|
+| `BOOST_PATH` | Boost prefix | `/usr/local` | `/opt/homebrew/opt/boost` |
+| `ZLIB_PATH` | zlib prefix | `/usr` | `/opt/homebrew/opt/zlib` |
+| `GSL_PATH` | GSL prefix | `/usr/local/gsl` | `/opt/homebrew/opt/gsl` |
+| `CPPZMQ_PATH` | cppzmq (`zmq.hpp`) prefix | `/usr/local` | `/opt/homebrew/opt/cppzmq` |
+| `ZMQ_PATH` | zeromq prefix | `/usr/local` | `/opt/homebrew/opt/zeromq` |
+| `JSON_PATH` | nlohmann/json prefix | `/usr/local` | `/opt/homebrew/opt/nlohmann-json` |
+| `CRYPTOPP_PATH` | Crypto++ prefix | `/usr/local` | `/opt/homebrew/opt/cryptopp` |
+| `GTEST_PATH` | Google Test prefix (unit tests) | `/usr` | `/opt/homebrew/opt/googletest` |
+| `LOCAL_LIB_PATH` | extra `-L`/rpath root for home-dir installs | `/usr/local` | `/usr/local` |
+
+Every variable expects a **prefix** — Make appends `/include` or `/lib` as
+needed. `KSPRPROJ` is still required (it points at the repo root).
+
+## Easiest: auto-detect with `mk_kaspr/detect_paths.sh`
+
+From a fresh checkout, run the detection script. It probes the common prefix
+locations (`$HOME/local`, `/usr/local`, `/usr`, `/opt/local`, and
+`/opt/homebrew/opt/<pkg>` on macOS) and emits a ready-to-source export block —
+including `KSPRPROJ` for this checkout:
+
+```bash
+# Print what would be exported
+./mk_kaspr/detect_paths.sh
+
+# Apply to the current shell
+eval "$(./mk_kaspr/detect_paths.sh)"
+
+# Or append to ~/.bashrc (review first!)
+./mk_kaspr/detect_paths.sh >> ~/.bashrc && source ~/.bashrc
+```
+
+Audit mode lists whether each library was found and where, with install hints
+for anything missing:
+
+```bash
+./mk_kaspr/detect_paths.sh --check
+```
+
+Boost prefixes like `$HOME/local/boost190` / `boost188` are enumerated
+newest-first, so a newer local install shadows an older one.
+
+## Quick recipes
+
+### Plain system install (`/usr`, `/usr/local`)
+
+Nothing to set — the defaults work.
+
+```bash
+export KSPRPROJ=$(pwd)
+make -j
+```
+
+### Home-directory prefixes (e.g. `$HOME/local/boost190`)
+
+```bash
+# ~/.bashrc
+export KSPRPROJ=$HOME/kaspar-hft
+export BOOST_PATH=$HOME/local/boost190
+export JSON_PATH=$HOME/local
+export CRYPTOPP_PATH=$HOME/local
+export LOCAL_LIB_PATH=$HOME/local
+```
+
+### macOS with Homebrew (arm64)
+
+Defaults already point at `/opt/homebrew/opt/<pkg>`; override only if a library
+is installed elsewhere:
+
+```bash
+export BOOST_PATH=/opt/homebrew/opt/boost@1.90
+```
+
+## Why it used to be hardcoded
+
+Earlier versions baked one developer's `$HOME/local` layout
+(`/home/vmayeski/local/boost190`, …) into `=` assignments. That broke builds on
+any other account and made merges noisy. `?=` leaves the assignment
+conditional: set it in the environment and the build uses your values; unset it
+and the build uses a sane default.
+
+## Common gotchas
+
+- `export …` in `.bashrc` only affects **new** shells — `source ~/.bashrc` or
+  open a fresh terminal.
+- Point a variable at the **prefix**, not at `.../include` or `.../lib`.
+- Overriding one path doesn't force overrides elsewhere — set only the ones
+  that differ from the defaults.

--- a/mk_kaspr/detect_paths.sh
+++ b/mk_kaspr/detect_paths.sh
@@ -1,0 +1,204 @@
+#!/bin/bash
+#
+# Copyright (c) 2026 Vincent Mayeski / M2 Tech (16425640 Canada Inc.).
+# Licensed under the MIT License. See LICENSE file in the project root.
+#
+# detect_paths.sh — auto-detect third-party library prefixes for kaspar.
+#
+# Searches the common prefix locations (system paths, /usr/local, ~/local,
+# /opt/*, and Homebrew on macOS) for each library mk_kaspr/glob_begin.mk
+# consumes, and emits a shell-sourceable `export` block on stdout.
+#
+# Usage:
+#
+#   ./mk_kaspr/detect_paths.sh                    # print export block to stdout
+#   ./mk_kaspr/detect_paths.sh >> ~/.bashrc       # append to bashrc (review first)
+#   eval "$(./mk_kaspr/detect_paths.sh)"          # apply to the current shell
+#   ./mk_kaspr/detect_paths.sh --check            # table of findings + install hints
+#   ./mk_kaspr/detect_paths.sh --verbose          # log every probed path to stderr
+#
+# The first probe that matches in the first prefix that contains it wins.
+
+set -u
+
+mode=emit
+verbose=0
+for arg in "$@"; do
+    case "$arg" in
+        --check|-c)   mode=check ;;
+        --verbose|-v) verbose=1 ;;
+        --help|-h)
+            sed -n '6,21p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            echo "unknown flag: $arg (use --help)" >&2
+            exit 2
+            ;;
+    esac
+done
+
+log() { [ "$verbose" -eq 1 ] && echo "  $*" >&2 || true; }
+
+# Candidate prefixes, highest priority first. Home-dir builds shadow
+# /usr/local, which shadows /opt, which shadows /usr.
+PREFIXES_GENERIC=(
+    "$HOME/local"
+    "/usr/local"
+    "/opt/local"
+    "/usr"
+)
+
+BREW_ROOT=/opt/homebrew/opt
+
+# detect_with_probes <var> <brew-pkg> <extra-prefix...> -- <probe...>
+# Tries each (prefix x probe) combo; first match wins. Prints the prefix.
+detect_with_probes() {
+    local var="$1" brew_pkg="$2"
+    shift 2
+    local -a extras=()
+    while [ $# -gt 0 ] && [ "$1" != "--" ]; do
+        extras+=("$1"); shift
+    done
+    [ "${1:-}" = "--" ] && shift
+    local -a probes=("$@")
+
+    local -a candidates=()
+    if [ -n "$brew_pkg" ] && [ -d "$BREW_ROOT/$brew_pkg" ]; then
+        candidates+=("$BREW_ROOT/$brew_pkg")
+    fi
+    candidates+=("${extras[@]}" "${PREFIXES_GENERIC[@]}")
+
+    for pfx in "${candidates[@]}"; do
+        for probe in "${probes[@]}"; do
+            if [ -e "$pfx/$probe" ]; then
+                log "$var: matched $probe at $pfx"
+                echo "$pfx"; return 0
+            fi
+            log "$var: no $probe at $pfx"
+        done
+    done
+    return 1
+}
+
+# ----- per-library detectors ----------------------------------------
+
+# Boost: home-dir builds often version the prefix (boost190, boost188).
+# Enumerate newest-first (version sort) so a newer local install shadows an
+# older one.
+detect_boost() {
+    local -a versioned=()
+    for d in "$HOME"/local/boost*; do
+        [ -d "$d" ] && versioned+=("$d")
+    done
+    if [ ${#versioned[@]} -gt 0 ]; then
+        mapfile -t versioned < <(printf '%s\n' "${versioned[@]}" | sort -Vr)
+    fi
+    detect_with_probes BOOST_PATH boost "${versioned[@]}" -- include/boost/version.hpp
+}
+
+detect_zlib()    { detect_with_probes ZLIB_PATH    zlib          -- include/zlib.h; }
+detect_gsl()     { detect_with_probes GSL_PATH     gsl "$HOME"/local/gsl /usr/local/gsl \
+                       -- include/gsl/gsl_version.h include/gsl/gsl_math.h; }
+detect_cppzmq()  { detect_with_probes CPPZMQ_PATH  cppzmq        -- include/zmq.hpp; }
+detect_zmq()     { detect_with_probes ZMQ_PATH     zeromq        -- include/zmq.h; }
+detect_json()    { detect_with_probes JSON_PATH    nlohmann-json -- include/nlohmann/json.hpp; }
+detect_gtest()   { detect_with_probes GTEST_PATH   googletest    -- include/gtest/gtest.h; }
+
+# Crypto++: cryptlib.h is the stable anchor header; config.h/version.h vary
+# across releases.
+detect_cryptopp() {
+    detect_with_probes CRYPTOPP_PATH cryptopp \
+        -- include/cryptopp/cryptlib.h include/cryptopp/config.h include/cryptopp/version.h
+}
+
+# LOCAL_LIB_PATH: any prefix that has a populated lib/ dir.
+detect_local_lib() {
+    for pfx in "$HOME/local" "/usr/local"; do
+        [ -d "$pfx/lib" ] && { echo "$pfx"; return 0; }
+    done
+    return 1
+}
+
+# ----- install-hint text ---------------------------------------------
+
+install_hint() {
+    case "$1" in
+        BOOST_PATH)    printf '      apt: libboost-all-dev | dnf: boost-devel | brew: boost\n      source: https://www.boost.org/users/download/ (need 1.88+)\n' ;;
+        ZLIB_PATH)     printf '      apt: zlib1g-dev | dnf: zlib-devel | brew: zlib\n' ;;
+        GSL_PATH)      printf '      apt: libgsl-dev | dnf: gsl-devel | brew: gsl\n' ;;
+        CPPZMQ_PATH)   printf '      apt: cppzmq-dev | dnf: cppzmq-devel | brew: cppzmq\n' ;;
+        ZMQ_PATH)      printf '      apt: libzmq3-dev | dnf: zeromq-devel | brew: zeromq\n' ;;
+        JSON_PATH)     printf '      apt: nlohmann-json3-dev | dnf: json-devel | brew: nlohmann-json\n' ;;
+        CRYPTOPP_PATH) printf '      apt: libcrypto++-dev | dnf: cryptopp-devel | brew: cryptopp\n' ;;
+        GTEST_PATH)    printf '      apt: libgtest-dev | dnf: gtest-devel | brew: googletest\n' ;;
+        LOCAL_LIB_PATH) printf '      No action needed — points at a prefix with a lib/ dir (default /usr/local).\n' ;;
+    esac
+}
+
+# ----- run detection --------------------------------------------------
+
+declare -A FOUND
+FOUND[BOOST_PATH]=$(detect_boost       || echo "")
+FOUND[ZLIB_PATH]=$(detect_zlib         || echo "")
+FOUND[GSL_PATH]=$(detect_gsl           || echo "")
+FOUND[CPPZMQ_PATH]=$(detect_cppzmq     || echo "")
+FOUND[ZMQ_PATH]=$(detect_zmq           || echo "")
+FOUND[JSON_PATH]=$(detect_json         || echo "")
+FOUND[CRYPTOPP_PATH]=$(detect_cryptopp || echo "")
+FOUND[GTEST_PATH]=$(detect_gtest       || echo "")
+FOUND[LOCAL_LIB_PATH]=$(detect_local_lib || echo "")
+
+VARS=(BOOST_PATH ZLIB_PATH GSL_PATH CPPZMQ_PATH ZMQ_PATH JSON_PATH CRYPTOPP_PATH GTEST_PATH LOCAL_LIB_PATH)
+
+# ----- output ---------------------------------------------------------
+
+if [ "$mode" = "check" ]; then
+    printf "%-16s  %s\n" VAR "DETECTED PREFIX"
+    printf "%-16s  %s\n" "----" "---------------"
+    missing=()
+    for v in "${VARS[@]}"; do
+        val=${FOUND[$v]:-}
+        if [ -n "$val" ]; then
+            printf "\033[32m%-16s\033[0m  %s\n" "$v" "$val"
+        else
+            printf "\033[31m%-16s\033[0m  %s\n" "$v" "(not found)"
+            missing+=("$v")
+        fi
+    done
+    if [ ${#missing[@]} -gt 0 ]; then
+        echo >&2
+        echo "==== ${#missing[@]} dependency prefix(es) not found ====" >&2
+        for v in "${missing[@]}"; do
+            echo "  * $v" >&2
+            install_hint "$v" >&2
+        done
+        echo >&2
+        echo "Install the package, or set the variable by hand:" >&2
+        echo "    export <VAR>=/absolute/path/to/prefix   # e.g. BOOST_PATH=\$HOME/local/boost190" >&2
+        exit 1
+    fi
+    echo >&2
+    echo "All dependencies detected. Apply via:  eval \"\$(mk_kaspr/detect_paths.sh)\"" >&2
+    exit 0
+fi
+
+# Default (emit) mode. `printf %q` quotes metacharacters safely.
+cat <<'HEAD'
+# Auto-generated by mk_kaspr/detect_paths.sh
+# Append to ~/.bashrc, or source via:  eval "$(mk_kaspr/detect_paths.sh)"
+HEAD
+for v in "${VARS[@]}"; do
+    val=${FOUND[$v]:-}
+    if [ -n "$val" ]; then
+        printf 'export %s=%q\n' "$v" "$val"
+    else
+        echo "# $v NOT DETECTED — see 'mk_kaspr/detect_paths.sh --check' for install hints"
+    fi
+done
+
+# KSPRPROJ is the repo root — this script lives in <repo>/mk_kaspr/.
+repo=$(cd "$(dirname "$0")/.." && pwd)
+echo
+echo "# Repo root (detected from this script's location)"
+printf 'export KSPRPROJ=%q\n' "$repo"

--- a/mk_kaspr/glob_begin.mk
+++ b/mk_kaspr/glob_begin.mk
@@ -41,24 +41,31 @@ FRAME_REF_PATH=$(INSTALL_PATH)/frame_ref
 # OS detection
 UNAME_S := $(shell uname -s)
 
-# External dependencies - OS-specific paths
+# External dependency prefixes — overridable from the environment (`?=`, so a
+# shell `export` wins over the default). Defaults match a vanilla system
+# install; set overrides in your shell profile — or run mk_kaspr/detect_paths.sh
+# to auto-detect them — when the libs live under a home-dir prefix. See
+# mk_kaspr/PATHS.md.
 ifeq ($(UNAME_S),Darwin)
-    BOOST_PATH=/opt/homebrew/opt/boost
-    ZLIB_PATH=/opt/homebrew/opt/zlib
-    GSL_PATH=/opt/homebrew/opt/gsl
-    CPPZMQ_PATH=/opt/homebrew/opt/cppzmq
-    ZMQ_PATH=/opt/homebrew/opt/zeromq
-    JSON_PATH=/opt/homebrew/opt/nlohmann-json
-    CRYPTOPP_PATH=/opt/homebrew/opt/cryptopp
+    BOOST_PATH    ?= /opt/homebrew/opt/boost
+    ZLIB_PATH     ?= /opt/homebrew/opt/zlib
+    GSL_PATH      ?= /opt/homebrew/opt/gsl
+    CPPZMQ_PATH   ?= /opt/homebrew/opt/cppzmq
+    ZMQ_PATH      ?= /opt/homebrew/opt/zeromq
+    JSON_PATH     ?= /opt/homebrew/opt/nlohmann-json
+    CRYPTOPP_PATH ?= /opt/homebrew/opt/cryptopp
 else
-    BOOST_PATH=/home/vmayeski/local/boost190
-    ZLIB_PATH=/usr
-    GSL_PATH=/usr/local/gsl
-    CPPZMQ_PATH=/usr/local
-    ZMQ_PATH=/usr/local
-    JSON_PATH=/home/vmayeski/local
-    CRYPTOPP_PATH=/home/vmayeski/local
+    BOOST_PATH    ?= /usr/local
+    ZLIB_PATH     ?= /usr
+    GSL_PATH      ?= /usr/local/gsl
+    CPPZMQ_PATH   ?= /usr/local
+    ZMQ_PATH      ?= /usr/local
+    JSON_PATH     ?= /usr/local
+    CRYPTOPP_PATH ?= /usr/local
 endif
+
+# Extra -L / rpath root for home-dir installs (Linux links -L$(LOCAL_LIB_PATH)/lib).
+LOCAL_LIB_PATH ?= /usr/local
 
 INCL=\
 -I$(ACTORS_PATH)/include \
@@ -86,7 +93,6 @@ INCL=\
 -I$(ZMQ_PATH)/include \
 -I$(JSON_PATH)/include \
 -I$(CRYPTOPP_PATH)/include \
--I/home/vmayeski/local/include/mysql \
 -I$(INSTALL_PATH)
 
 MFLAGS=$(INCL) $(EXTRA_INCL) $(STANDARD) $(CFLAGS_SPEC)
@@ -128,11 +134,11 @@ else
     CFLAGS_DBG = -O0 -DDEBUG -DLOGDEBUG -ggdb $(DEFINES_COMMON) $(DEFINES_DBG) $(WARNINGS) -rdynamic -Wl,-rpath,/usr/local/lib64:/usr/local/lib:$(BOOST_PATH)/lib:/usr/local/zlib/lib:/usr/local/gsl/lib -mcx16 -mavx2
 
     # Linux link flags
-    LDFLAGS_COMMON = -L$(BOOST_PATH)/lib -L$(ZLIB_PATH)/lib -L$(GSL_PATH)/lib -L/usr/local/lib -L/usr/local/lib64 -L/home/vmayeski/local/lib -lboost_thread -lboost_filesystem -lpthread -lzmq
+    LDFLAGS_COMMON = -L$(BOOST_PATH)/lib -L$(ZLIB_PATH)/lib -L$(GSL_PATH)/lib -L/usr/local/lib -L/usr/local/lib64 -L$(LOCAL_LIB_PATH)/lib -lboost_thread -lboost_filesystem -lpthread -lzmq
 endif
 
-LDFLAGS_OPT = $(LDFLAGS_COMMON) -Wl,-rpath,/usr/local/lib64:/usr/local/lib:$(BOOST_PATH)/lib:/home/vmayeski/local/lib:/usr/local/gsl/lib
-LDFLAGS_DBG = $(LDFLAGS_COMMON) -Wl,-rpath,/usr/local/lib64:/usr/local/lib:$(BOOST_PATH)/lib:/home/vmayeski/local/lib:/usr/local/gsl/lib
+LDFLAGS_OPT = $(LDFLAGS_COMMON) -Wl,-rpath,/usr/local/lib64:/usr/local/lib:$(BOOST_PATH)/lib:$(LOCAL_LIB_PATH)/lib:/usr/local/gsl/lib
+LDFLAGS_DBG = $(LDFLAGS_COMMON) -Wl,-rpath,/usr/local/lib64:/usr/local/lib:$(BOOST_PATH)/lib:$(LOCAL_LIB_PATH)/lib:/usr/local/gsl/lib
 
 # Common library definitions for kaspr applications
 # Actors library path


### PR DESCRIPTION
The build **hardcoded one developer's home-dir prefixes** (`/home/vmayeski/local/boost190`, `/home/vmayeski/local`, …) via `=` in `mk_kaspr/glob_begin.mk` and `actors/cpp/Makefile`, which breaks the build on any other account (the caveat noted in the recent Build-docs PR).

## Changes
- **Overridable paths.** Every external dependency prefix (`BOOST_PATH`, `ZLIB_PATH`, `GSL_PATH`, `CPPZMQ_PATH`, `ZMQ_PATH`, `JSON_PATH`, `CRYPTOPP_PATH`, `GTEST_PATH`, `LOCAL_LIB_PATH`) is now a `?=` default with a sane vanilla system-install value, so a shell `export` wins without editing the makefiles.
- **`mk_kaspr/detect_paths.sh`** — probes the common prefixes (`$HOME/local`, `/usr/local`, `/usr`, `/opt/local`, Homebrew on macOS), emits a source-able `export` block (including `KSPRPROJ` for the checkout), with a `--check` audit mode + per-library install hints. Boost versioned prefixes (`boost190`, `boost188`) are enumerated newest-first.
- **`mk_kaspr/PATHS.md`** — documents the overridable variables and per-environment recipes.
- Dropped the stale hardcoded `-I/home/vmayeski/local/include/mysql`; routed the remaining home-dir `-L`/rpath through the new `LOCAL_LIB_PATH`.
- README Build section points at `detect_paths.sh` / `PATHS.md`.

Ports the mechanism used in the private tree, re-implemented under kaspar-hft's MIT header (no MySQL, since this repo doesn't use it).

## Verification (Linux, in a container)
- `detect_paths.sh --check` correctly detected zlib/gsl/cppzmq/zmq/json/crypto++/gtest at `/usr` and flagged Boost (nonstandard location) for manual setting.
- With paths detected + `BOOST_PATH` exported: `actors/cpp` and `mcast_recv` libraries build, and the **actor-framework unit tests pass 24/24**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)