### PR TITLE
docs: add tick-to-trade latency to Performance Characteristics

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ kaspr {
 
 ## Performance Characteristics
 
+- **Tick-to-trade latency**: median in the ~100 µs range; p99 under 1 ms (expected)
 - **Message dispatch**: O(1) vector lookup by message ID — no virtual dispatch, no hash maps
 - **Actor send**: Sub-microsecond enqueue (mutex + condition variable, no allocation on hot path)
 - **Book update to strategy**: Single `EndOfBurst` message per MDP3 incremental cycle


### PR DESCRIPTION
Adds the end-to-end latency headline to Performance Characteristics: **median in the ~100 µs range; p99 under 1 ms** (tick-to-trade, expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)