### PR TITLE
security: remove committed MySQL password from kaspr.ini

### DIFF
--- a/kaspr/config/kaspr.ini
+++ b/kaspr/config/kaspr.ini
@@ -23,7 +23,7 @@ kaspr {
     mysql {
         host localhost
         user etrading
-        password @Etrading646
+        password CHANGEME
         database kasprowy_paper_trading_db
     }
 }


### PR DESCRIPTION
Replaces the hardcoded DB password in `kaspr/config/kaspr.ini` with a `CHANGEME` placeholder. The DB actor is stubbed and MySQL is not linked, so the block is currently unused.

**Note:** the old value remains in git history (already public), so it should be treated as compromised and rotated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)