### PR TITLE
docs+tool: document message-ID gotcha; remove stale CHOPIN_PROJ

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,30 @@ handle_messages!(MyStrategy,
 See [actors/cpp/CLAUDE_AGENT_GUIDE.md](actors/cpp/CLAUDE_AGENT_GUIDE.md) for the complete C++ framework
 reference, and [actors/rust/DEVELOPER_GUIDE.md](actors/rust/DEVELOPER_GUIDE.md) for the Rust API.
 
+### Message IDs — a gotcha when adding messages
+
+Every actor message carries a **globally-unique integer ID** in `[0, 511]`,
+assigned by hand as a template parameter:
+
+```cpp
+struct MyMessage : public actors::Message_N<100> { /* ... */ };
+```
+
+That ID drives O(1) dispatch (`handler_cache[msg_id]`) and message-type
+identification. **There is no compile-time check that IDs are unique** — if two
+message types pick the same ID the collision is *silent*: messages get routed to
+the wrong handler or interpreted as the wrong type (undefined behavior), not a
+build error.
+
+So when you add a message type, pick an ID nothing else uses and run the checker
+before committing — it scans the tree and flags any duplicate `Message_N<ID>`:
+
+```bash
+python3 setclassid/setclassid.py     # exits noisily on a duplicate ID
+```
+
+See [`setclassid/README.md`](setclassid/README.md).
+
 ## Console
 
 A running `kaspr` process exposes a **ZMQ request/reply control console** (the

--- a/setclassid/README.md
+++ b/setclassid/README.md
@@ -29,15 +29,15 @@ CFSM (Communicating Finite State Machine) uses message IDs for:
 
 ### Prerequisites
 
-Set the `CHOPIN_PROJ` environment variable to the m2 project root:
+Set `KSPRPROJ` to the repository root (optional — defaults to the repo the script lives in):
 ```bash
-export CHOPIN_PROJ=/home/vm/m2
+export KSPRPROJ=/path/to/kaspar-hft
 ```
 
 ### Basic Usage
 
 ```bash
-cd /home/vm/m2/setclassid
+cd $KSPRPROJ/setclassid
 python3 setclassid.py
 ```
 
@@ -89,7 +89,7 @@ This indicates a message ID exceeds the maximum (511).
 ### Step 1: Run the Script to Find Available IDs
 
 ```bash
-cd /home/vm/m2/setclassid
+cd $KSPRPROJ/setclassid
 python3 setclassid.py
 ```
 
@@ -197,7 +197,7 @@ If the script reports a duplicate:
 ### Finding All Messages for a Specific Component
 
 ```bash
-cd /home/vm/m2/setclassid
+cd $KSPRPROJ/setclassid
 python3 setclassid.py | grep "bbg/include/bbg/msg"
 ```
 
@@ -211,7 +211,7 @@ Example Makefile integration:
 ```makefile
 .PHONY: check-msgids
 check-msgids:
-	@cd /home/vm/m2/setclassid && python3 setclassid.py > /dev/null && echo "✓ Message IDs are unique"
+	@cd $KSPRPROJ/setclassid && python3 setclassid.py > /dev/null && echo "✓ Message IDs are unique"
 
 build: check-msgids
 	# ... rest of build
@@ -219,20 +219,20 @@ build: check-msgids
 
 ## Troubleshooting
 
-### Error: "KeyError: 'CHOPIN_PROJ'"
+### Error: "KeyError: 'KSPRPROJ'"
 
 **Cause**: Environment variable not set.
 
 **Fix**:
 ```bash
-export CHOPIN_PROJ=/home/vm/m2
+export KSPRPROJ=/path/to/kaspar-hft
 ```
 
 Or add to `~/.bashrc` for persistence.
 
 ### Error: "No such file or directory: '/interface'"
 
-**Cause**: `CHOPIN_PROJ` set to wrong path.
+**Cause**: `KSPRPROJ` set to wrong path.
 
 **Fix**: Ensure it points to the m2 root (not a subdirectory).
 

--- a/setclassid/setclassid.py
+++ b/setclassid/setclassid.py
@@ -14,8 +14,10 @@ import re
 # maximum is 512
 #
 
-rdir=os.environ["CHOPIN_PROJ"]
-print (rdir)
+# Repo root: honor KSPRPROJ if set, otherwise default to this script's repo
+# (setclassid/ lives at the top level).
+rdir = os.environ.get("KSPRPROJ") or os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+print(rdir)
 
 def listFilesRecursive(dirP,pattern):
     ret = listFiles(dirP,pattern)


### PR DESCRIPTION
**Message-ID gotcha** — every `actors::Message_N<ID>` needs a globally-unique id in `[0,511]`; there's **no compile-time uniqueness check**, so a collision silently misroutes messages (UB), not a build error. Added a README subsection explaining this and pointing at the `setclassid` checker.

**Stale `CHOPIN_PROJ`** — a leftover env-var name from the old project. It was the last of the `CHOPIN_PROJ` references (mk_kaspr was fixed in #25), both in `setclassid/`:
- `setclassid.py` now reads `KSPRPROJ`, defaulting to the repo root — runs with no env var, never `KeyError`s.
- `setclassid/README.md`: `CHOPIN_PROJ` -> `KSPRPROJ` and fixed run paths.

Verified: `python3 setclassid/setclassid.py` runs and scans IDs with no env var set.

(Note: setclassid/README's *example-output* blocks still show old-project paths like `cfsm/bbg/pycalc` — illustrative, left as-is.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)