### PR TITLE
genconfig: note why the stdlib XML parser is safe here (re #23)

### DIFF
--- a/genconfig/genconfig_mdp3_3.py
+++ b/genconfig/genconfig_mdp3_3.py
@@ -5,6 +5,11 @@
 #
 # Licensed under the MIT License. See LICENSE file in the project root.
 
+# NOTE: this parses XML downloaded from CME's authenticated SFTP server — a
+# trusted source — so the stdlib parser is fine here. If this ever parses
+# untrusted / user-supplied XML, switch to defusedxml
+# (`from defusedxml import ElementTree as ET`) to harden against XXE / XML-bomb
+# attacks (CWE-611).
 import xml.etree.ElementTree as ET
 import paramiko
 import sys


### PR DESCRIPTION
Response to the automated XXE finding in #23. No code change — the XML is downloaded from CME's authenticated SFTP server (a trusted source), so stdlib `ElementTree` is fine here. Added a comment recording that, and pointing to `defusedxml` if this ever parses untrusted input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)