### PR TITLE
docs: remove two remaining false lock-free claims

### DIFF
--- a/FILE_STRUCTURE.md
+++ b/FILE_STRUCTURE.md
@@ -83,7 +83,7 @@ In-process actor system with message passing and lifecycle management, plus an i
 | `Actor.hpp` | Actor base class — message handlers, send/subscribe |
 | `ActorRef.hpp` | Lightweight actor reference (address + send) |
 | `Message.hpp` | Base message type with routing metadata |
-| `Queue.hpp` | Lock-free SPSC message queue |
+| `Queue.hpp` | Abstract message-queue interface |
 | `BQueue.hpp` | Bounded queue variant |
 | `HybridBuffer.hpp` | Hybrid stack/heap buffer for messages |
 | `HybridCB.hpp` | Hybrid circular buffer |

--- a/light/SHADOW_ALGORITHM.md
+++ b/light/SHADOW_ALGORITHM.md
@@ -58,7 +58,7 @@ This prevents over-trading while still reacting to market conditions.
 
 4. **Minimal latency path** — one message handler (`eob_handler`) with a short decision tree. No model evaluation, no network round-trips for decision-making. The critical path is: receive EOB → check flags → send Order to SOM.
 
-5. **Lock-free coordination** — `QCoord` (queue coordinator) and `PCoord` (position coordinator) use shared memory to coordinate multiple lights per instrument without message passing overhead.
+5. **Shared-memory coordination** — `QCoord` (queue coordinator) and `PCoord` (position coordinator) coordinate multiple lights per instrument via shared memory guarded by fine-grained mutexes, without message-passing overhead.
 
 ## Configuration
 


### PR DESCRIPTION
Follow-up to #22 (which only touched README). A full-repo + metadata scan found two genuine false claims still present:

- **FILE_STRUCTURE.md** called `Queue.hpp` a *Lock-free SPSC message queue* — it's an **abstract base class** (pure-virtual push/pop, no atomics). → *Abstract message-queue interface*.
- **SHADOW_ALGORITHM.md** said *Lock-free coordination* for QCoord/PCoord — the main README states those are *guarded by fine-grained mutexes*. → *Shared-memory coordination*.

Everything else with 'lock-free' is legit: the *Lock-Free Isn't Free* / *Lock-Free Illusion* **article titles**, and the rust/CLAUDE.md **'NOT lock-free'** clarifications. The GitHub repo description already reads 'actor framework with sub-microsecond dispatch' (no 'lock-free').

🤖 Generated with [Claude Code](https://claude.com/claude-code)