### PR TITLE
actors: make Message id a data member; drop per-message virtual call

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,9 @@ Additional per-component guides:
 ### Adding a new message type
 
 1. Create header at `<lib>/include/<lib>/msg/MyMsg.hpp`
-2. Extend `Message_N<ID>` with unique ID >= 100
+2. Extend `MessageT<MyMsg>` (auto-assigned collision-free id, preferred), or
+   `Message_N<N>` with a unique `N` in 1–511 if you need a compile-time-constant
+   id (run `setclassid/setclassid.py` to catch `Message_N` collisions)
 3. Register handler in receiving actor's constructor
 
 ### Modifying handler_if.hpp

--- a/README.md
+++ b/README.md
@@ -204,27 +204,37 @@ reference, and [actors/rust/DEVELOPER_GUIDE.md](actors/rust/DEVELOPER_GUIDE.md) 
 
 ### Message IDs — a gotcha when adding messages
 
-Every actor message carries a **globally-unique integer ID** in `[0, 511]`,
-assigned by hand as a template parameter:
+Every actor message carries an integer ID that drives O(1) dispatch
+(`handler_cache[msg_id]`) and message-type identification. The ID is a data
+member set at construction; `get_message_id()` is a non-virtual accessor (no
+vtable call on the dispatch path).
+
+**Prefer `MessageT<Derived>`** — its ID is auto-assigned at first use from a
+counter starting at 512, so it is collision-free by construction:
+
+```cpp
+struct MyMessage : public actors::MessageT<MyMessage> { /* ... */ };
+```
+
+**`Message_N<N>`** fixes the ID to a compile-time constant in `[1, 511]` (use it
+only when you need `MyMessage::id` as a constant, e.g. a `case` label):
 
 ```cpp
 struct MyMessage : public actors::Message_N<100> { /* ... */ };
 ```
 
-That ID drives O(1) dispatch (`handler_cache[msg_id]`) and message-type
-identification. **There is no compile-time check that IDs are unique** — if two
-message types pick the same ID the collision is *silent*: messages get routed to
-the wrong handler or interpreted as the wrong type (undefined behavior), not a
-build error.
-
-So when you add a message type, pick an ID nothing else uses and run the checker
-before committing — it scans the tree and flags any duplicate `Message_N<ID>`:
+For `Message_N`, **there is no compile-time check that IDs are unique** — if two
+types pick the same ID the collision is *silent*: messages get routed to the
+wrong handler or interpreted as the wrong type (undefined behavior), not a build
+error. So pick an ID nothing else uses and run the checker before committing — it
+scans the tree and flags any duplicate `Message_N<N>`:
 
 ```bash
 python3 setclassid/setclassid.py     # exits noisily on a duplicate ID
 ```
 
-See [`setclassid/README.md`](setclassid/README.md).
+See [`setclassid/README.md`](setclassid/README.md). (`MessageT` types need no
+such check — their 512+ IDs never overlap the hand-assigned range.)
 
 ## Console
 

--- a/actors/cpp/Actor.cpp
+++ b/actors/cpp/Actor.cpp
@@ -156,7 +156,7 @@ void Actor::operator()() noexcept
     m->last = last;
     reply_to = m->sender;
 
-    bool is_shutdown = m->get_message_id() == 5;
+    bool is_shutdown = m->get_message_id() == msg::Shutdown::id;
 
     process_message_internal(m);
 

--- a/actors/cpp/CLAUDE_AGENT_GUIDE.md
+++ b/actors/cpp/CLAUDE_AGENT_GUIDE.md
@@ -51,7 +51,7 @@ Each Actor:
 - **Manager**: Registers actors, manages threads, CPU affinity
 - **Actor**: Base class with handler dispatch, send/reply/fast_send
 - **ActorRef**: `std::variant<LocalActorRef, RustActorRef>` — a local C++ actor or a Rust actor over the in-process FFI bridge (same `send`/`fast_send` API)
-- **Message**: `Message_N<ID>` template with integer IDs for O(1) dispatch
+- **Message**: `MessageT<Derived>` (auto id) or `Message_N<N>` (fixed compile-time id); each carries an integer id (a data member; `get_message_id()` is a non-virtual accessor) for O(1) dispatch
 - **BQueue**: Blocking queue (mutex + condition_variable) for actor mailbox
 - **Group**: Multiple actors on single thread (lightweight)
 
@@ -59,12 +59,29 @@ Each Actor:
 
 ### Adding a New Message Type
 
-1. Define struct extending `Message_N<ID>` with a unique integer ID
-2. IDs 1-9 are reserved for system messages; use >= 100 for user messages
+Prefer `MessageT<Derived>` — its id is auto-assigned (collision-free, from a
+counter starting at 512):
 
 ```cpp
 #include "actors/Message.hpp"
 
+struct OrderMessage : public MessageT<OrderMessage> {
+    std::string order_id;
+    double price;
+    int quantity;
+
+    OrderMessage(std::string id = "", double p = 0.0, int q = 0)
+        : order_id(std::move(id)), price(p), quantity(q) {}
+};
+```
+
+Use `Message_N<N>` only when you need the id as a compile-time constant
+(`OrderMessage::id`, a `case` label). N must be a unique integer in 1–511 (512+
+is reserved for `MessageT`); IDs 1-9 are reserved for system messages, use >= 100
+for user messages. Run `setclassid/setclassid.py` to catch `Message_N` id
+collisions.
+
+```cpp
 struct OrderMessage : public Message_N<100> {
     std::string order_id;
     double price;

--- a/actors/cpp/examples/ping_pong.cpp
+++ b/actors/cpp/examples/ping_pong.cpp
@@ -87,8 +87,8 @@ public:
     auto* pong = new PongActor();
     auto* ping = new PingActor(pong, this, 5);
 
-    manage(pong);
-    manage(ping);
+    add_to_manage_q(pong);
+    add_to_manage_q(ping);
   }
 };
 

--- a/actors/cpp/examples/remote_ping.cpp
+++ b/actors/cpp/examples/remote_ping.cpp
@@ -86,19 +86,19 @@ public:
 
         // Create ZMQ sender (now an Actor - must be managed!)
         zmq_sender_ = make_shared<ZmqSender>("tcp://localhost:5002");
-        manage(zmq_sender_.get());
+        add_to_manage_q(zmq_sender_.get());
 
         // Create remote ref to pong on other process
         ActorRef remote_pong = zmq_sender_->remote_ref("pong", remote_pong_endpoint);
 
         // Create ping actor
         auto* ping_actor = new PingActor(std::move(remote_pong), this);
-        manage(ping_actor);
+        add_to_manage_q(ping_actor);
 
         // Create ZMQ receiver for incoming Pong messages
         auto* zmq_receiver = new ZmqReceiver(local_endpoint, zmq_sender_);
         zmq_receiver->register_actor("ping", ping_actor);
-        manage(zmq_receiver);
+        add_to_manage_q(zmq_receiver);
     }
 };
 

--- a/actors/cpp/examples/remote_pong.cpp
+++ b/actors/cpp/examples/remote_pong.cpp
@@ -81,16 +81,16 @@ public:
 
         // Create ZMQ sender for replies (now an Actor - must be managed!)
         zmq_sender_ = make_shared<ZmqSender>("tcp://localhost:5001");
-        manage(zmq_sender_.get());
+        add_to_manage_q(zmq_sender_.get());
 
         // Create pong actor
         auto* pong_actor = new PongActor();
-        manage(pong_actor);
+        add_to_manage_q(pong_actor);
 
         // Create ZMQ receiver and register local actors
         auto* zmq_receiver = new ZmqReceiver(endpoint, zmq_sender_);
         zmq_receiver->register_actor("pong", pong_actor);
-        manage(zmq_receiver);
+        add_to_manage_q(zmq_receiver);
     }
 };
 

--- a/actors/cpp/include/actors/Actor.hpp
+++ b/actors/cpp/include/actors/Actor.hpp
@@ -23,6 +23,10 @@
 
 #define ACTOR_BQUEUE_SIZE 64
 #define ACTOR_HANDLER_CACHE_SIZE 2048
+// The handler cache is indexed directly by message id, so its size is the id
+// ceiling enforced in Message.hpp (kMessageIdCap). Keep the two in lockstep.
+static_assert(ACTOR_HANDLER_CACHE_SIZE == actors::detail::kMessageIdCap,
+              "ACTOR_HANDLER_CACHE_SIZE must equal actors::detail::kMessageIdCap");
 
 // Register a message handler for this actor
 // Usage: MESSAGE_HANDLER(MessageType, handler_method)

--- a/actors/cpp/include/actors/Message.hpp
+++ b/actors/cpp/include/actors/Message.hpp
@@ -8,6 +8,8 @@
  */
 
 #include <atomic>
+#include <stdexcept>
+#include <string>
 
 namespace actors
 {
@@ -82,27 +84,52 @@ namespace actors
    * MessageT<Derived> for new types, which assigns a collision-free id
    * automatically.
    */
-  template <int N>
-  struct Message_N : public Message
-  {
-    static constexpr int id = N;  // compile-time id, for case labels / comparisons
-    Message_N() noexcept : Message(N) {}
-  };
-
   namespace detail
   {
     // Ids handed out by MessageT start above the hand-assigned 0-511 range so
     // they can never collide with a Message_N<N>.
     inline constexpr int kFirstDynamicMessageId = 512;
 
+    // Every id indexes Actor::handler_cache / dont_have_handler, which are sized
+    // ACTOR_HANDLER_CACHE_SIZE. Ids must stay below this cap or dispatch reads
+    // out of bounds. This is the single source of truth; Actor.hpp static_asserts
+    // that ACTOR_HANDLER_CACHE_SIZE matches it.
+    inline constexpr int kMessageIdCap = 2048;
+  }
+
+  // A hand-assigned id must live in [0, kFirstDynamicMessageId) so it never
+  // collides with the dynamically-assigned MessageT range -- checked at compile
+  // time, unlike cross-type uniqueness (see setclassid.py).
+  template <int N>
+  struct Message_N : public Message
+  {
+    static_assert(N >= 0 && N < detail::kFirstDynamicMessageId,
+                  "Message_N<N> id must be in [0, 512); 512+ is reserved for MessageT");
+    static constexpr int id = N;  // compile-time id, for case labels / comparisons
+    Message_N() noexcept : Message(N) {}
+  };
+
+  namespace detail
+  {
     inline std::atomic<int>& message_id_counter() noexcept
     {
       static std::atomic<int> c{kFirstDynamicMessageId};
       return c;
     }
-    inline int next_message_id() noexcept
+    // Assign the next dynamic id, failing loudly rather than handing back an id
+    // that would index past the end of Actor::handler_cache. The number of
+    // distinct MessageT types is (returned id - kFirstDynamicMessageId + 1).
+    inline int next_message_id()
     {
-      return message_id_counter().fetch_add(1, std::memory_order_relaxed);
+      const int id = message_id_counter().fetch_add(1, std::memory_order_relaxed);
+      if (id >= kMessageIdCap)
+      {
+        throw std::runtime_error(
+          "actors: too many MessageT types (" + std::to_string(id - kFirstDynamicMessageId + 1) +
+          "); id " + std::to_string(id) + " would exceed the handler-cache cap of " +
+          std::to_string(kMessageIdCap) + " (raise ACTOR_HANDLER_CACHE_SIZE / kMessageIdCap)");
+      }
+      return id;
     }
   }
 
@@ -112,10 +139,11 @@ namespace actors
    * The function-local static gives thread-safe, once-only initialisation. Ids
    * are NOT stable across runs (assignment follows first-use order) and are not
    * constant expressions -- they are in-process dispatch indices only, never
-   * serialised (remote transport keys on the type name).
+   * serialised (remote transport keys on the type name). Throws if the id space
+   * (kMessageIdCap) is exhausted.
    */
   template <class T>
-  inline int message_id() noexcept
+  inline int message_id()
   {
     static const int id = detail::next_message_id();
     return id;
@@ -131,7 +159,9 @@ namespace actors
   template <class Derived>
   struct MessageT : public Message
   {
-    MessageT() noexcept : Message(message_id<Derived>()) {}
+    // Not noexcept: the first construction of each Derived assigns its id and
+    // throws if the id space is exhausted (see next_message_id).
+    MessageT() : Message(message_id<Derived>()) {}
   };
 }
 

--- a/actors/cpp/include/actors/Message.hpp
+++ b/actors/cpp/include/actors/Message.hpp
@@ -7,6 +7,8 @@
  * Licensed under the MIT License. See LICENSE file in the project root.
  */
 
+#include <atomic>
+
 namespace actors
 {
   class Actor;
@@ -14,24 +16,34 @@ namespace actors
   /**
    * Base class for all messages in the actor system
    *
-   * Messages are the only way actors communicate.
-   * Each message type has a unique ID (0-511 for optimal performance).
+   * Messages are the only way actors communicate. Each message type has an
+   * integer id used for O(1) handler dispatch.
+   *
+   * The id is stored as a data member (`msg_id_`) rather than returned by a
+   * virtual function: `Actor::call_handler` reads it on every message, and a
+   * virtual call there cannot be devirtualised (the static type is
+   * `const Message*`). A member read is a single load. The id is set once at
+   * construction and is immutable identity thereafter.
+   *
+   * `msg_id_` is declared last so it packs into the tail padding after the two
+   * bools; the object size is unchanged.
    */
   struct Message
   {
-    virtual int get_message_id() const = 0;
+    // Non-virtual: a plain member read, not a vtable dispatch.
+    int get_message_id() const noexcept { return msg_id_; }
+
     mutable Actor *sender = nullptr;
     mutable Actor *destination = nullptr;
     mutable bool is_fast = false;
     mutable bool last = false;
-
-    Message() = default;
 
     Message(const Message& other)
       : sender(other.sender)
       , destination(nullptr)
       , is_fast(other.is_fast)
       , last(other.last)
+      , msg_id_(other.msg_id_)  // identity is preserved across a copy
     {}
 
     Message& operator=(const Message& other) {
@@ -40,15 +52,24 @@ namespace actors
         destination = nullptr;
         is_fast = other.is_fast;
         last = other.last;
+        // msg_id_ is identity: not reassigned.
       }
       return *this;
     }
 
-    virtual ~Message() = default;
+    virtual ~Message() = default;  // messages are deleted through Message*
+
+  protected:
+    // Protected so Message stays uninstantiable now that the pure virtual is
+    // gone; subclasses supply their id via Message_N<N> or MessageT<Derived>.
+    explicit Message(int id) noexcept : msg_id_(id) {}
+
+  private:
+    int msg_id_;
   };
 
   /**
-   * Template for creating message types with a specific ID
+   * Message type with a fixed, compile-time id.
    *
    * Usage:
    *   struct MyMessage : public actors::Message_N<100> {
@@ -56,12 +77,61 @@ namespace actors
    *     MyMessage(int d) : data(d) {}
    *   };
    *
-   * Use IDs 0-511 for best performance (handler cache optimization)
+   * Ids must be unique per type; there is no compile-time uniqueness check
+   * across the tree (run setclassid/setclassid.py to catch duplicates). Prefer
+   * MessageT<Derived> for new types, which assigns a collision-free id
+   * automatically.
    */
   template <int N>
   struct Message_N : public Message
   {
-    constexpr int get_message_id() const override { return N; }
+    static constexpr int id = N;  // compile-time id, for case labels / comparisons
+    Message_N() noexcept : Message(N) {}
+  };
+
+  namespace detail
+  {
+    // Ids handed out by MessageT start above the hand-assigned 0-511 range so
+    // they can never collide with a Message_N<N>.
+    inline constexpr int kFirstDynamicMessageId = 512;
+
+    inline std::atomic<int>& message_id_counter() noexcept
+    {
+      static std::atomic<int> c{kFirstDynamicMessageId};
+      return c;
+    }
+    inline int next_message_id() noexcept
+    {
+      return message_id_counter().fetch_add(1, std::memory_order_relaxed);
+    }
+  }
+
+  /**
+   * One dense, process-unique id per type T, assigned on first use.
+   *
+   * The function-local static gives thread-safe, once-only initialisation. Ids
+   * are NOT stable across runs (assignment follows first-use order) and are not
+   * constant expressions -- they are in-process dispatch indices only, never
+   * serialised (remote transport keys on the type name).
+   */
+  template <class T>
+  inline int message_id() noexcept
+  {
+    static const int id = detail::next_message_id();
+    return id;
+  }
+
+  /**
+   * Message type whose id is auto-assigned (collision-free). CRTP: the base is
+   * templated on the derived type so message_id<Derived>() names a distinct id.
+   *
+   * Usage:
+   *   struct MyMessage : public actors::MessageT<MyMessage> { int data; };
+   */
+  template <class Derived>
+  struct MessageT : public Message
+  {
+    MessageT() noexcept : Message(message_id<Derived>()) {}
   };
 }
 

--- a/actors/cpp/include/actors/act/Manager.hpp
+++ b/actors/cpp/include/actors/act/Manager.hpp
@@ -42,7 +42,7 @@ class ZmqReceiver;
    *   public:
    *     MyManager() {
    *       set_registry("tcp://localhost:5555");  // Connect to GlobalRegistry
-   *       manage(new MyActor(), {0}, 50, SCHED_FIFO);  // Pin to CPU 0
+   *       add_to_manage_q(new MyActor(), {0}, 50, SCHED_FIFO);  // Pin to CPU 0
    *     }
    *   };
    *

--- a/actors/cpp/include/actors/msg/README.md
+++ b/actors/cpp/include/actors/msg/README.md
@@ -117,12 +117,17 @@ publisher->send(new actors::msg::Subscribe(), this);
 
 ## Creating Custom Messages
 
-Define custom messages by inheriting from `Message_N<ID>`:
+Two ways to define a message. Both give every type an integer id used for O(1)
+handler dispatch (`Actor::call_handler` indexes `handler_cache` by that id).
+`get_message_id()` is a non-virtual accessor over a data member set at
+construction — not a virtual call.
+
+**Preferred — `MessageT<Derived>` (auto-assigned, collision-free id):**
 
 ```cpp
 #include "actors/Message.hpp"
 
-struct MyMessage : public actors::Message_N<100> {
+struct MyMessage : public actors::MessageT<MyMessage> {
   int value;
   std::string text;
 
@@ -130,4 +135,20 @@ struct MyMessage : public actors::Message_N<100> {
 };
 ```
 
-**Note:** Use IDs >= 100 for custom messages. IDs 1-99 are reserved for system messages.
+The id is assigned automatically on first use from a counter starting at 512, so
+it can never collide with a hand-assigned id.
+
+**Fixed id — `Message_N<N>` (compile-time constant id):**
+
+```cpp
+struct MyMessage : public actors::Message_N<100> {
+  int value;
+  MyMessage(int v) : value(v) {}
+};
+```
+
+Use `Message_N<N>` only when you need the id as a compile-time constant (e.g. a
+`case` label or a `msg::MyMessage::id` comparison). **N must be unique and in the
+range 1–511** (512+ is reserved for `MessageT`); there is no compile-time
+uniqueness check across the tree — run `setclassid/setclassid.py` to catch
+duplicates. IDs 1-99 are reserved for system messages; use >= 100 for user messages.

--- a/actors/cpp/tests/test_message_id.cpp
+++ b/actors/cpp/tests/test_message_id.cpp
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026 Vincent Mayeski / M2 Tech (16425640 Canada Inc.).
+ * Contact: v@m2te.ch | https://www.linkedin.com/in/vmayeski/
+ *
+ * Licensed under the MIT License. See LICENSE file in the project root.
+ *
+ * Tests for message identity: Message_N compile-time ids, MessageT
+ * auto-assigned ids (uniqueness + thread-safe first use), the non-virtual
+ * get_message_id() accessor, and that the object layout did not grow.
+ */
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <thread>
+#include <type_traits>
+#include <unordered_set>
+#include <vector>
+
+#include "actors/Message.hpp"
+#include "actors/msg/Shutdown.hpp"
+
+using namespace actors;
+
+namespace {
+
+struct FixedMsg : public Message_N<123> { int payload = 7; };
+
+struct AutoA : public MessageT<AutoA> {};
+struct AutoB : public MessageT<AutoB> {};
+struct AutoC : public MessageT<AutoC> {};
+
+} // namespace
+
+// --- compile-time invariants -------------------------------------------------
+
+// Message must stay uninstantiable now that the pure virtual is gone (the
+// int-taking constructor is protected).
+static_assert(!std::is_constructible_v<Message, int>,
+              "Message(int) is protected; Message must not be directly constructible");
+static_assert(!std::is_default_constructible_v<Message>,
+              "Message has no public default constructor");
+
+// Message_N exposes its id as a compile-time constant.
+static_assert(Message_N<42>::id == 42, "Message_N<N>::id must be N");
+static_assert(msg::Shutdown::id == 5, "Shutdown id is 5");
+
+// Layout guard: msg_id_ is declared last so it packs into the tail padding
+// after the two bools. On LP64 that keeps Message at 32 bytes
+// (vptr 8 + 2 ptrs 16 + 2 bools + int 4, padded to 32). Declaring the id first
+// would push it to 40. If this fails, the member was reordered.
+static_assert(sizeof(void*) != 8 || sizeof(Message) == 32,
+              "Message grew: id must pack into tail padding, not lead the layout");
+
+// --- runtime behaviour -------------------------------------------------------
+
+TEST(MessageId, FixedIdMatchesTemplateParam) {
+    FixedMsg m;
+    EXPECT_EQ(m.get_message_id(), 123);
+    EXPECT_EQ(FixedMsg::id, 123);
+}
+
+TEST(MessageId, GetMessageIdIsNotVirtual) {
+    // A non-virtual member function pointer has the plain function-pointer
+    // shape; more directly, calling through a value (no vtable) yields the id.
+    FixedMsg m;
+    const Message& base = m;
+    EXPECT_EQ(base.get_message_id(), 123);  // resolved statically, no override needed
+}
+
+TEST(MessageId, AutoIdsAreUniqueAndStable) {
+    const int a1 = message_id<AutoA>();
+    const int b1 = message_id<AutoB>();
+    const int a2 = message_id<AutoA>();
+    EXPECT_EQ(a1, a2);                 // stable across calls
+    EXPECT_NE(a1, b1);                 // distinct types -> distinct ids
+    EXPECT_GE(a1, detail::kFirstDynamicMessageId);
+    EXPECT_GE(b1, detail::kFirstDynamicMessageId);
+}
+
+TEST(MessageId, AutoIdMatchesConstructedMessage) {
+    AutoC m;
+    EXPECT_EQ(m.get_message_id(), message_id<AutoC>());
+}
+
+TEST(MessageId, FirstUseIsThreadSafe) {
+    // Race the first use of four fresh types across many threads; no type may
+    // end up with two different ids (function-local static once-only init).
+    struct T1 {}; struct T2 {}; struct T3 {}; struct T4 {};
+    constexpr int kThreads = 16;
+    std::atomic<int> mismatches{0};
+    std::vector<std::thread> ts;
+    for (int i = 0; i < kThreads; ++i) {
+        ts.emplace_back([&] {
+            int a = message_id<T1>(), b = message_id<T2>();
+            int c = message_id<T3>(), d = message_id<T4>();
+            // all four must be pairwise distinct on every thread
+            std::unordered_set<int> s{a, b, c, d};
+            if (s.size() != 4) ++mismatches;
+        });
+    }
+    for (auto& t : ts) t.join();
+    EXPECT_EQ(mismatches.load(), 0);
+}

--- a/actors/cpp/tests/test_message_id.cpp
+++ b/actors/cpp/tests/test_message_id.cpp
@@ -76,6 +76,12 @@ TEST(MessageId, AutoIdsAreUniqueAndStable) {
     EXPECT_NE(a1, b1);                 // distinct types -> distinct ids
     EXPECT_GE(a1, detail::kFirstDynamicMessageId);
     EXPECT_GE(b1, detail::kFirstDynamicMessageId);
+    // Ids index Actor::handler_cache, so they must stay under the cap. Exhausting
+    // the cap (assigning > kMessageIdCap - kFirstDynamicMessageId types) makes
+    // next_message_id() throw rather than hand back an out-of-bounds index; that
+    // path can't be unit-tested without polluting the process-global counter.
+    EXPECT_LT(a1, detail::kMessageIdCap);
+    EXPECT_LT(b1, detail::kMessageIdCap);
 }
 
 TEST(MessageId, AutoIdMatchesConstructedMessage) {

--- a/frame_ref/include/frame/mda/OrderID.hpp
+++ b/frame_ref/include/frame/mda/OrderID.hpp
@@ -7,14 +7,16 @@
  * Licensed under the MIT License. See LICENSE file in the project root.
  */
 
-#include "actors/Message.hpp"
 #include "enum/exch_code.hpp"
 
 namespace frame
 {
     namespace mda
     {
-        class OrderID : public actors::Message
+        // Static-only helper for packing/unpacking (exchange, order-id) pairs.
+        // Never instantiated or sent as a message; the private constructor keeps
+        // it non-instantiable.
+        class OrderID
         {
             OrderID(){}
 

--- a/setclassid/README.md
+++ b/setclassid/README.md
@@ -8,7 +8,7 @@
 
 ## Overview
 
-This script validates that all actor message IDs are unique across the entire codebase. Every message inherits from `actors::Message_N<ID>` where `ID` must be a unique integer between 0 and 511.
+This script validates that all *hand-assigned* actor message IDs are unique across the entire codebase. Messages that inherit from `actors::Message_N<ID>` fix `ID` to a compile-time constant that must be a unique integer between 1 and 511. (Messages that inherit from `actors::MessageT<Derived>` instead get an id auto-assigned at runtime from a counter starting at 512, so they are collision-free by construction and are not the concern of this script.)
 
 ## Why Message IDs Must Be Unique
 


### PR DESCRIPTION
## Problem

`Message::get_message_id()` is pure virtual, and `Actor::call_handler` calls it on **every** message. Because the static type there is `const Message*`, the compiler cannot devirtualise it, so every message pays a vtable dispatch — two dependent loads plus an indirect branch — for a value that is constant per message type.

Codegen (arm64, `-O2`):

```
virtual get_message_id       cached member (this PR)
  ldr x8, [x0]   ; vptr         ldr w0, [x0, #off]
  ldr x1, [x8]   ; vtable slot  ret
  br  x1         ; indirect
```

Separately, `Actor::operator()` hardcoded the shutdown check as `m->get_message_id() == 5`, a magic number with no link to `msg::Shutdown`.

## Change

- **`Message`**: store the id as a data member set once in a `protected explicit Message(int)` ctor; `get_message_id()` becomes a non-virtual single load. `msg_id_` is declared **last** so it packs into the tail padding after the two bools — `sizeof(Message)` is unchanged (32 on LP64; declaring it first would make it 40). `virtual ~Message()` stays (messages are deleted through `Message*`), so the vtable remains — only the id dispatch is removed.
- **`Message_N<N>`**: unchanged for the ~100 existing call sites. It forwards `N` to the base ctor and now exposes `static constexpr int id = N`.
- **`Actor.cpp`**: `== 5` → `== msg::Shutdown::id` (compile-time constant, no object constructed).
- **`MessageT<Derived>`** (new, CRTP): auto-assigns a collision-free id above the hand-assigned 0–511 range, for new message types. Nothing is migrated to it in this PR.

## Testing

New `actors/cpp/tests/test_message_id.cpp` (5 tests, all pass via `make test`):
- fixed ids match the template param; `Shutdown::id == 5`
- auto ids are unique, stable, and above 512
- thread-safe first use (16 threads racing, no duplicate ids)
- **layout guard**: `static_assert(sizeof(Message) == 32)` on LP64 so the id can't be reordered back to the front
- `Message` is not directly constructible (still abstract)

Verified: `actors/cpp` library + tests build and pass; representative `Message_N` headers (actors, mdp3) compile against the new base with correct ids.

**Note:** a full-repo `make` could not complete in this environment due to a **pre-existing** failure compiling `chutil/theta.cpp` under the optimized `-flto`/`-march=native` path — reproduced on clean `main` with this branch's changes stashed, so it is unrelated to this change. This PR also lights up the `make test` target in `actors/cpp` for the first time (main had no `tests/test_*.cpp`).

Related report (local, not in repo): the id-collision half of `BUG-message-id-manual-assignment.md`. The PMF `reinterpret_cast` UB in dispatch is intentionally left for a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)