### PR TITLE
perf: measure fast_send vs a bare function call

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,23 @@ ping → pong → reply, one message in flight. Apple Silicon / macOS, `-O3
 \* per-sample timing quantizes to the ~40 ns `steady_clock` tick; ~24 ns is the
 amortized mean.
 
+**How much does the actor machinery cost over a bare function call?** Timed
+cleanly (one clock-read pair around a tight loop, identical trivial work on a
+stack input):
+
+| | per op |
+|---|---:|
+| direct function call | ~1 ns |
+| `fast_send` (dispatch, no reply) | ~8 ns |
+
+So **`fast_send` adds ~7 ns over a plain call** — the uncontended mutex, the
+message field writes, the `handler_cache[id]` pointer-to-member dispatch, and the
+reply `unique_ptr`. That is the entire framework tax on the fast path: single-digit
+nanoseconds, ~1/18 of a same-thread `send` and ~1/300 of a cross-thread one. How
+it's measured (`run_direct_call` vs `fast_send`, section D):
+[perf README](actors/cpp/perf/README.md#d-fast_send-vs-a-bare-function-call) ·
+[`bench_pingpong.cpp`](actors/cpp/perf/bench_pingpong.cpp).
+
 **Allocation** — the MemoryPool is a compile-time switch (`DISABLE_MEMORY_POOL`).
 Same pooled message types, grouped-send round trip (amortized ns):
 

--- a/actors/cpp/perf/README.md
+++ b/actors/cpp/perf/README.md
@@ -127,6 +127,27 @@ message on the **stack** when you can (saves an alloc/free outright); the reply
 so allocate replies from the **MemoryPool** to turn a ~15 ns global alloc into a
 ~3 ns pooled one and to cut the allocator tail.
 
+### D. fast_send vs a bare function call
+
+How much does the actor machinery cost over just calling a function? The bench
+times both cleanly (one clock-read pair around a tight loop — no per-iteration
+clock reads, so neither number carries the ~28 ns clock overhead the `amort`
+column does), doing identical trivial work on a stack input:
+
+| | per op |
+|---|---:|
+| direct function call (`noinline`) | ~1 ns |
+| `fast_send` (dispatch, no reply) | ~8 ns |
+
+So **`fast_send` adds ~7 ns over a bare call** — that ~7 ns is the uncontended
+mutex lock/unlock, the message field writes, the `handler_cache[id]`
+pointer-to-member dispatch, and the reply-`unique_ptr` wrapping. The ratio prints
+as ~4–10× only because the ~1 ns baseline is so small that its measurement is
+noisy; the **+7 ns absolute delta is the stable, meaningful figure**. For
+context, that ~7 ns is ~1/18 of a same-thread `send` (~125 ns) and ~1/300 of a
+cross-thread `send` (~2250 ns) — the framework tax on the fast path is single-digit
+nanoseconds.
+
 ## Caveats
 
 - **Clock resolution.** `steady_clock` ticks at ~40 ns here, so per-sample

--- a/actors/cpp/perf/bench_pingpong.cpp
+++ b/actors/cpp/perf/bench_pingpong.cpp
@@ -251,6 +251,14 @@ perf::LatencyStats run_fastsend_stack(const std::string& label, size_t measured,
   return s;
 }
 
+// Sink so the compiler cannot optimize the trivial handler work away.
+volatile uint64_t g_sink = 0;
+
+// The handler's "work", also callable directly (no framework) as a baseline.
+// noinline so the direct-call baseline is a real call comparable to the
+// framework's indirect dispatch, rather than being inlined to nothing.
+[[gnu::noinline]] void echo_work(const Ping* m) noexcept { g_sink += m->seq; }
+
 // Handler that does not reply -- isolates dispatch (+ input alloc) from the reply.
 template <class PingT>
 class SinkActor : public Actor
@@ -263,8 +271,35 @@ public:
   }
 
 private:
-  void on_ping(const PingT*) noexcept { /* no reply */ }
+  void on_ping(const PingT* m) noexcept { g_sink += m->seq; } // same work as echo_work
 };
+
+// Baseline: call the handler's work as a plain function -- no actor framework,
+// no mutex, no dispatch table, no message wrapping. Pairs with
+// run_fastsend_stack_noreply (same stack input, same trivial work), so the
+// difference is exactly fast_send's per-call overhead.
+perf::LatencyStats run_direct_call(const std::string& label, size_t measured, size_t warmup)
+{
+  std::vector<uint64_t> samples;
+  samples.reserve(measured);
+  const size_t total = measured + warmup;
+  uint64_t win_start = 0;
+  for (size_t i = 0; i < total; ++i)
+  {
+    if (i == warmup)
+      win_start = perf::now_ns();
+    Ping ping(i);
+    const uint64_t t0 = perf::now_ns();
+    echo_work(&ping); // direct function call, no framework
+    const uint64_t t1 = perf::now_ns();
+    if (i >= warmup)
+      samples.push_back(t1 - t0);
+  }
+  const uint64_t win_end = perf::now_ns();
+  auto s = perf::LatencyStats::from(label, samples);
+  s.amortized = measured ? static_cast<double>(win_end - win_start) / measured : 0.0;
+  return s;
+}
 
 // fast_send in a loop, stack input, no reply: pure dispatch cost.
 perf::LatencyStats run_fastsend_stack_noreply(const std::string& label, size_t measured,
@@ -373,6 +408,7 @@ int main(int argc, char** argv)
     rows.push_back(run_fastsend_heap_noreply<PingPool>("fs pooled noreply", measured, warmup));
     rows.push_back(run_fastsend_stack("fs stack+reply", measured, warmup));
     rows.push_back(run_fastsend_stack_noreply("fs stack noreply", measured, warmup));
+    rows.push_back(run_direct_call("direct call (base)", measured, warmup));
   }
 
   if (rows.empty())
@@ -392,5 +428,43 @@ int main(int argc, char** argv)
     perf::print_row(r);
   std::printf("(one-way ~ round-trip / 2 for the symmetric echo handler; "
               "fast_send rows near ~40ns are at steady_clock resolution)\n");
+
+  // fast_send vs a plain function call, measured CLEANLY: each is timed with a
+  // single clock-read pair around a tight loop (no per-iteration clock reads),
+  // so neither number carries the ~28 ns of clock overhead the table's amort
+  // column does. Both do identical trivial work on a stack input, so the delta
+  // is fast_send's framework overhead (mutex + message-field setup +
+  // handler-cache dispatch + reply wrapping) over a bare call.
+  if (all || section == "fastsend")
+  {
+    SinkActor<Ping> sink;
+    NullActor sender;
+    const size_t total = measured + warmup;
+
+    uint64_t c0 = 0;
+    for (size_t i = 0; i < total; ++i)
+    {
+      if (i == warmup)
+        c0 = perf::now_ns();
+      Ping ping(i);
+      echo_work(&ping);
+    }
+    const double call_ns = static_cast<double>(perf::now_ns() - c0) / measured;
+
+    uint64_t f0 = 0;
+    for (size_t i = 0; i < total; ++i)
+    {
+      if (i == warmup)
+        f0 = perf::now_ns();
+      Ping ping(i);
+      auto reply = sink.fast_send(&ping, &sender);
+    }
+    const double fs_ns = static_cast<double>(perf::now_ns() - f0) / measured;
+
+    std::printf("\nfast_send vs direct function call (clean amortized, per op):\n");
+    std::printf("  direct call : %5.1f ns\n", call_ns);
+    std::printf("  fast_send   : %5.1f ns  (+%.1f ns, %.1fx a bare call)\n", fs_ns,
+                fs_ns - call_ns, call_ns > 0 ? fs_ns / call_ns : 0.0);
+  }
   return 0;
 }


### PR DESCRIPTION
Answers "how much slower is `fast_send` than a plain function call?"

Adds a `noinline` direct-call baseline doing identical trivial work on a stack input, and a **clean amortized** comparison (one clock-read pair around each tight loop — no per-iteration clock reads, so neither number carries the ~28 ns clock overhead the table's `amort` column does).

Result (Apple Silicon / macOS, indicative):

| | per op |
|---|---:|
| direct function call | ~1 ns |
| `fast_send` (dispatch, no reply) | ~8 ns |

**`fast_send` adds ~7 ns over a bare call** — uncontended mutex lock/unlock, message field writes, `handler_cache[id]` pointer-to-member dispatch, and reply-`unique_ptr` wrapping. The printed ratio (~4–10×) is noisy because the ~1 ns baseline is tiny; the **+7 ns absolute delta is the stable figure**. Documented as section D in the perf README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)