### PR TITLE
build: rebuild libactors.a from scratch (fix stale-archive segfault)

### DIFF
--- a/actors/cpp/Makefile
+++ b/actors/cpp/Makefile
@@ -73,10 +73,19 @@ debug: $(LIBG)
 REGISTRY_CLIENT_OBJ_OPT = $(OBJDIRO)/src/registry/RegistryClient.o
 REGISTRY_CLIENT_OBJ_DBG = $(OBJDIRG)/src/registry/RegistryClient.o
 
+# Remove the archive before rebuilding it. `ar rcs` inserts/replaces members by
+# name but never REMOVES ones that are no longer prerequisites, so an archive can
+# silently accumulate stale objects (e.g. `*.cpp.o` left by an old CMake `build/`
+# tree, whose names differ from the Makefile's `*.o`). The linker can then resolve
+# a symbol from a stale object compiled against old headers -> wrong struct layout
+# -> a hard-to-debug crash. `rm -f` first makes the archive exactly its
+# prerequisites on every build.
 $(LIB): $(OBJS_OPT) $(REGISTRY_CLIENT_OBJ_OPT) $(CONSOLE_OBJS_OPT)
+	rm -f $@
 	ar rcs $@ $^
 
 $(LIBG): $(OBJS_DBG) $(REGISTRY_CLIENT_OBJ_DBG) $(CONSOLE_OBJS_DBG)
+	rm -f $@
 	ar rcs $@ $^
 
 $(OBJDIRO)/%.o: %.cpp | $(OBJDIRO)
@@ -192,5 +201,6 @@ $(MONITORING_TEST_BIN): $(MONITORING_TEST_SRC) $(LIB)
 
 clean:
 	rm -rf $(OBJDIRO) $(OBJDIRG) $(LIB) $(LIBG) $(TEST_BIN) $(COORD_ACTOR_BIN) $(COORD_TEST_BIN) $(REGISTRY_BIN) $(REGISTRY_TEST_BIN) $(MONITORING_TEST_BIN) examples/ping_pong examples/remote_pong examples/remote_ping
+	rm -rf build   # stale CMake tree: its *.cpp.o objects can poison libactors.a (see $(LIB) rule)
 
 .PHONY: all opt debug clean examples test coordination-actor test-coordination registry test-registry test-monitoring


### PR DESCRIPTION
**Reported from an HFT-server run** of the actor benchmarks (`actors/cpp/perf/BENCH_ON_HFT_SERVER.md`): the first build segfaulted in `call_handler` in every section, pool ON and OFF.

## Root cause

`ar rcs` inserts/replaces archive members **by name** but never **removes** ones that are no longer prerequisites. An old CMake `build/` tree had left `*.cpp.o` objects in the checkout; their names differ from the Makefile's `*.o`, so `ar r` never replaced them and `libactors.a` ended up with **16 members where the Makefile lists 8**. The linker resolved `call_handler` from a **stale** object compiled against pre-pull headers → `handler_cache` read at the wrong offset in `Actor` → wild jump / segfault. (Invisible to the compiler, UBSan and ASan because dispatch goes through a `reinterpret_cast`ed pointer-to-member — see #39.)

## Fix

- `rm -f $@` before `ar rcs` in both the opt (`$(LIB)`) and debug (`$(LIBG)`) archive rules, so the archive is exactly its prerequisites on every build.
- `clean:` also removes a stale `build/` CMake tree.

## Verified

- Clean archive contains exactly the 8 intended objects, no `*.cpp.o`.
- Injected a stale `Stale.cpp.o`, forced a rebuild → it is **removed** (was persisting before).
- `make test` 5/5; perf benches build and run.

Follow-up (not in this PR): the object rule has no header-dependency tracking (`-MMD -MP`), so editing a header doesn't trigger a rebuild — same failure mode waiting to happen. Worth a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)