### PR TITLE
docs: MessageT everywhere — no message-ID hardcoding in any guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,9 +121,10 @@ Additional per-component guides:
 ### Adding a new message type
 
 1. Create header at `<lib>/include/<lib>/msg/MyMsg.hpp`
-2. Extend `MessageT<MyMsg>` (auto-assigned collision-free id, preferred), or
-   `Message_N<N>` with a unique `N` in 1–511 if you need a compile-time-constant
-   id (run `setclassid/setclassid.py` to catch `Message_N` collisions)
+2. Extend `MessageT<MyMsg>` — the id is auto-assigned and collision-free. **Do
+   not hand-pick a message id.** (`Message_N<N>` is legacy: hard-coded id, not
+   uniqueness-checked; use only if you genuinely need a compile-time-constant id,
+   then run `setclassid/setclassid.py` to audit.)
 3. Register handler in receiving actor's constructor
 
 ### Modifying handler_if.hpp

--- a/actors/cpp/CLAUDE_AGENT_GUIDE.md
+++ b/actors/cpp/CLAUDE_AGENT_GUIDE.md
@@ -59,8 +59,8 @@ Each Actor:
 
 ### Adding a New Message Type
 
-Prefer `MessageT<Derived>` — its id is auto-assigned (collision-free, from a
-counter starting at 512):
+Inherit `MessageT<Derived>` — the id is auto-assigned and collision-free (from a
+counter starting at 512). **Do not hand-pick an id.**
 
 ```cpp
 #include "actors/Message.hpp"
@@ -75,22 +75,11 @@ struct OrderMessage : public MessageT<OrderMessage> {
 };
 ```
 
-Use `Message_N<N>` only when you need the id as a compile-time constant
-(`OrderMessage::id`, a `case` label). N must be a unique integer in 1–511 (512+
-is reserved for `MessageT`); IDs 1-9 are reserved for system messages, use >= 100
-for user messages. Run `setclassid/setclassid.py` to catch `Message_N` id
-collisions.
-
-```cpp
-struct OrderMessage : public Message_N<100> {
-    std::string order_id;
-    double price;
-    int quantity;
-
-    OrderMessage(std::string id = "", double p = 0.0, int q = 0)
-        : order_id(std::move(id)), price(p), quantity(q) {}
-};
-```
+> **Legacy `Message_N<N>`:** hard-codes the id to a compile-time constant and is
+> *not* uniqueness-checked, so two types can silently collide. Use it only if you
+> truly need the id as a constant expression (`OrderMessage::id`, a `case` label);
+> then run `setclassid/setclassid.py` to audit for duplicates. New messages use
+> `MessageT`.
 
 ### Adding a Message Handler
 

--- a/actors/cpp/include/actors/msg/README.md
+++ b/actors/cpp/include/actors/msg/README.md
@@ -117,12 +117,8 @@ publisher->send(new actors::msg::Subscribe(), this);
 
 ## Creating Custom Messages
 
-Two ways to define a message. Both give every type an integer id used for O(1)
-handler dispatch (`Actor::call_handler` indexes `handler_cache` by that id).
-`get_message_id()` is a non-virtual accessor over a data member set at
-construction — not a virtual call.
-
-**Preferred — `MessageT<Derived>` (auto-assigned, collision-free id):**
+Inherit `MessageT<Derived>`. The dispatch id is auto-assigned and collision-free
+by construction — **do not hand-pick an id.**
 
 ```cpp
 #include "actors/Message.hpp"
@@ -135,20 +131,11 @@ struct MyMessage : public actors::MessageT<MyMessage> {
 };
 ```
 
-The id is assigned automatically on first use from a counter starting at 512, so
-it can never collide with a hand-assigned id.
+Every type gets an integer id used for O(1) handler dispatch (`Actor::call_handler`
+indexes `handler_cache` by it); with `MessageT` it's assigned on first use from a
+counter starting at 512, and `get_message_id()` is a non-virtual member read.
 
-**Fixed id — `Message_N<N>` (compile-time constant id):**
-
-```cpp
-struct MyMessage : public actors::Message_N<100> {
-  int value;
-  MyMessage(int v) : value(v) {}
-};
-```
-
-Use `Message_N<N>` only when you need the id as a compile-time constant (e.g. a
-`case` label or a `msg::MyMessage::id` comparison). **N must be unique and in the
-range 1–511** (512+ is reserved for `MessageT`); there is no compile-time
-uniqueness check across the tree — run `setclassid/setclassid.py` to catch
-duplicates. IDs 1-99 are reserved for system messages; use >= 100 for user messages.
+> **Legacy:** `Message_N<N>` hard-codes the id to a compile-time constant. It is
+> not uniqueness-checked, so two types can silently collide — use it only if you
+> genuinely need the id as a constant expression (e.g. a `case` label), and run
+> `setclassid/setclassid.py` to audit existing ones. New messages use `MessageT`.

--- a/setclassid/README.md
+++ b/setclassid/README.md
@@ -6,9 +6,14 @@
 
 # setclassid - Message ID Uniqueness Checker
 
+> **New messages should inherit `actors::MessageT<Derived>`, which auto-assigns a
+> collision-free id — do NOT hand-pick an id, and you do not need this tool.**
+> This checker exists only to **audit existing legacy `Message_N<N>`** ids. The
+> "assign a new id" workflow below is legacy; don't use it for new message types.
+
 ## Overview
 
-This script validates that all *hand-assigned* actor message IDs are unique across the entire codebase. Messages that inherit from `actors::Message_N<ID>` fix `ID` to a compile-time constant that must be a unique integer between 1 and 511. (Messages that inherit from `actors::MessageT<Derived>` instead get an id auto-assigned at runtime from a counter starting at 512, so they are collision-free by construction and are not the concern of this script.)
+This script validates that all *hand-assigned* (legacy `Message_N<N>`) actor message IDs are unique across the codebase. `Message_N<ID>` fixes `ID` to a compile-time constant that must be a unique integer between 1 and 511. Messages that inherit from `actors::MessageT<Derived>` instead get an id auto-assigned at runtime from a counter starting at 512, so they are collision-free by construction and are not the concern of this script.
 
 ## Why Message IDs Must Be Unique
 


### PR DESCRIPTION
Follow-up to #51: sweep the remaining programming guides so **every** one leads with `MessageT<Derived>` and none teaches hand-picking a message id.

- **`actors/cpp/include/actors/msg/README.md`** ("Creating Custom Messages") — MessageT-only; dropped the `Message_N<100>` example and the "pick an ID / run the checker" walkthrough.
- **`actors/cpp/CLAUDE_AGENT_GUIDE.md`** ("Adding a New Message Type") — MessageT-only; removed the `Message_N<100>` code block.
- **`CLAUDE.md`** — step 2 now says "**do not hand-pick a message id**".
- **`setclassid/README.md`** — banner at the top: new messages use `MessageT` and don't need this tool; it only **audits legacy `Message_N`**. Overview reframed as legacy.

`Message_N` is a "legacy, only if you need a compile-time-constant id" callout everywhere now.

Left as-is (intentional): the C++/Rust interop codegen emits `Message_N<id>` for stable cross-language wire ids (a functional requirement, not a human-facing guide).

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)